### PR TITLE
bug fix for github integration

### DIFF
--- a/mops.toml
+++ b/mops.toml
@@ -7,5 +7,5 @@ repository = ""
 [dependencies]
 base = "0.6.27"
 http-parser = "0.1.0"
-"Itertools.mo" = "https://github.com/NatLabs/Itertools.mo#master"
 serde = "https://github.com/NatLabs/serde#master"
+"Itertools.mo" = "https://github.com/NatLabs/Itertools.mo#master"


### PR DESCRIPTION
There's a bug caused by the fallback to this [piece of code](https://github.com/ZenVoich/mops/blob/master/cli/cli.js#L66-L93).

Steps to reproduce:
- Add a GitHub repo directly to the mops file
```
     base = "https://github.com/dfinity/motoko-base#moc-0.7.2"
```
- then run `mops install base`

When the command is executed, it will display a log message instead of trying to install the GitHub package. This pull request is to fix this issue.