### PR TITLE
Fix progress bar corner case

### DIFF
--- a/cli/mops.js
+++ b/cli/mops.js
@@ -124,7 +124,7 @@ export function checkConfigFile() {
 }
 
 export function progressBar(step, total) {
-	let done = Math.round(step / total * 10);
+	let done = total > 0 ? Math.round(step / total * 10) : 0;
 	return `[${':'.repeat(done)}${' '.repeat(10 - done)}]`;
 }
 


### PR DESCRIPTION
This PR fixes an error message ("RangeError: Invalid count value") encountered while running `mops init` on [this repository](https://github.com/origyn-sa/origyn_nft). This was apparently caused by the local `done` variable being `Infinity` when `total` is zero and `step` is nonzero. 