### PR TITLE
Replace `ic0.app` with `icp-api.io` and `icp0.io`

### DIFF
--- a/.github/workflows/ci-production-cli-node14.yaml
+++ b/.github/workflows/ci-production-cli-node14.yaml
@@ -40,7 +40,7 @@ jobs:
           node-version: 14
       - uses: aviate-labs/setup-dfx@v0.2.3
         with:
-          dfx-version: 0.14.0
+          dfx-version: 0.14.1
 
       - name: Install npm packages
         run: |

--- a/.github/workflows/ci-production-cli-node14.yaml
+++ b/.github/workflows/ci-production-cli-node14.yaml
@@ -18,7 +18,7 @@ jobs:
           node-version: 14
       - uses: aviate-labs/setup-dfx@v0.2.3
         with:
-          dfx-version: 0.14.0
+          dfx-version: 0.14.1
 
       - name: Select moc version
         run: echo "DFX_MOC_PATH=$(npx mocv bin 0.9.1)/moc" >> $GITHUB_ENV

--- a/.github/workflows/ci-production-cli.yaml
+++ b/.github/workflows/ci-production-cli.yaml
@@ -41,7 +41,7 @@ jobs:
           node-version: 18
       - uses: aviate-labs/setup-dfx@v0.2.3
         with:
-          dfx-version: 0.14.0
+          dfx-version: 0.14.1
 
       - name: Select moc version
         run: echo "DFX_MOC_PATH=$(npx mocv bin 0.9.1)/moc" >> $GITHUB_ENV

--- a/.github/workflows/ci-production-cli.yaml
+++ b/.github/workflows/ci-production-cli.yaml
@@ -18,7 +18,7 @@ jobs:
           node-version: 18
       - uses: aviate-labs/setup-dfx@v0.2.3
         with:
-          dfx-version: 0.14.0
+          dfx-version: 0.14.1
 
       - name: Select moc version
         run: echo "DFX_MOC_PATH=$(npx mocv bin 0.9.1)/moc" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
           node-version: 18
       - uses: aviate-labs/setup-dfx@v0.2.3
         with:
-          dfx-version: 0.14.0
+          dfx-version: 0.14.1
 
       - name: Select moc version
         run: echo "DFX_MOC_PATH=$(npx mocv bin 0.9.1)/moc" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           node-version: 18
       - uses: aviate-labs/setup-dfx@v0.2.3
         with:
-          dfx-version: 0.14.0
+          dfx-version: 0.14.1
 
       - name: Select moc version
         run: echo "DFX_MOC_PATH=$(npx mocv bin 0.9.1)/moc" >> $GITHUB_ENV

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - uses: aviate-labs/setup-dfx@v0.2.3
         with:
-          dfx-version: 0.14.0
+          dfx-version: 0.14.1
 
       - name: install dfx
         run: dfx cache install

--- a/backend/main/main-canister.mo
+++ b/backend/main/main-canister.mo
@@ -497,6 +497,7 @@ actor {
 			case ("0.13.0") [("base", "0.7.6")];
 			case ("0.13.1") [("base", "0.7.6")];
 			case ("0.14.0") [("base", "0.8.7")];
+			case ("0.14.1") [("base", "0.8.8")];
 			case (_) {
 				switch (_getHighestVersion("base")) {
 					case (?ver) [("base", ver)];

--- a/cli/mops.js
+++ b/cli/mops.js
@@ -41,14 +41,14 @@ export function getNetwork() {
 	else if (network === 'staging') {
 		return {
 			network,
-			host: 'https://ic0.app',
+			host: 'https://icp-api.io',
 			canisterId: '2d2zu-vaaaa-aaaak-qb6pq-cai',
 		};
 	}
 	else if (network === 'ic') {
 		return {
 			network,
-			host: 'https://ic0.app',
+			host: 'https://icp-api.io',
 			canisterId: 'oknww-riaaa-aaaam-qaf6a-cai',
 		};
 	}

--- a/cli/templates/mops-test.yml
+++ b/cli/templates/mops-test.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 18
       - uses: aviate-labs/setup-dfx@v0.2.3
         with:
-          dfx-version: 0.14.0
+          dfx-version: 0.14.1
 
       - name: install dfx
         run: dfx cache install

--- a/dfx.json
+++ b/dfx.json
@@ -21,7 +21,7 @@
 			"packtool": "mops sources"
 		}
 	},
-	"dfx": "0.14.0",
+	"dfx": "0.14.1",
 	"networks": {
 		"staging": {
 			"type": "persistent",

--- a/frontend/logic/auth.ts
+++ b/frontend/logic/auth.ts
@@ -41,7 +41,7 @@ class Auth extends EventEmitter {
 		let client = await this.getClient();
 		return new Promise((resolve) => {
 			client.login({
-				identityProvider: 'https://identity.ic0.app',
+				identityProvider: 'https://identity.icp0.io',
 				maxTimeToLive: 1_000_000n * 1000n * 60n * 60n * 24n * 10n,
 				onSuccess: () => {
 					this.updateAuthState();

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -95,7 +95,7 @@ export default defineConfig({
 		proxy: {
 			// This proxies all http requests made to /api to our running dfx instance
 			'/api': {
-				// target: 'https://ic0.app/',
+				// target: 'https://icp-api.io/',
 				target: `http://127.0.0.1:${DFX_PORT}`,
 				changeOrigin: true,
 				rewrite: (path) => path.replace(/^\/api/, '/api'),

--- a/test/users.test.mo
+++ b/test/users.test.mo
@@ -90,8 +90,8 @@ test("setSite validation", func() {
 	assert Result.isOk(users.setSite(ensureNewUser(), "http://dfinity.org"));
 	assert Result.isOk(users.setSite(ensureNewUser(), "https://dfinity.org"));
 	assert Result.isOk(users.setSite(ensureNewUser(), "https://mops.one"));
-	assert Result.isOk(users.setSite(ensureNewUser(), "https://j4mwm-bqaaa-aaaam-qajbq-cai.ic0.app"));
-	assert Result.isOk(users.setSite(ensureNewUser(), "https://j4mwm-bqaaa-aaaam-qajbq-cai.ic0.app/base/docs/Array"));
+	assert Result.isOk(users.setSite(ensureNewUser(), "https://j4mwm-bqaaa-aaaam-qajbq-cai.icp0.io"));
+	assert Result.isOk(users.setSite(ensureNewUser(), "https://j4mwm-bqaaa-aaaam-qajbq-cai.icp0.io/base/docs/Array"));
 
 	assert Result.isErr(users.setSite(ensureNewUser(), "htt://mops.one"));
 	assert Result.isErr(users.setSite(ensureNewUser(), "dfinity.org"));


### PR DESCRIPTION
Since the `ic0.app` domain is [currently being phased out](https://forum.dfinity.org/t/follow-up-on-item-new-canisters-will-only-be-accessible-through-the-icp0-io-domain-existing-canisters-will-be-accessible-both-through-ic0-app-and-icp0-io/18889) in favor of `icp0.io` (webapps) and `icp-api.io` (API calls), this PR attempts to replace all occurrences of `ic0.app` with the new domain names. A few of my suggestions might need to be swapped with the other domain depending on how they are used, but this should get the codebase most of the way to completing the migration. 

Thanks again for your fantastic work on Mops over the past year!