### PR TITLE
Add Wasmtime flags for stable region unit testing

### DIFF
--- a/cli/commands/test/test.ts
+++ b/cli/commands/test/test.ts
@@ -147,7 +147,13 @@ export async function testWithReporter(reporter: Reporter, filter = '', mode: Te
 						return;
 					}
 					// run
-					let proc = spawn('wasmtime', ['--max-wasm-stack=2000000', wasmFile]);
+					let proc = spawn('wasmtime', [
+						'--max-wasm-stack=2000000',
+                        '--enable-cranelift-nan-canonicalization',
+                        '--wasm-features',
+                        'multi-memory,bulk-memory',
+						wasmFile
+					]);
 					await pipeMMF(proc, mmf);
 				}).finally(() => {
 					fs.rmSync(wasmFile, {force: true});

--- a/cli/commands/test/test.ts
+++ b/cli/commands/test/test.ts
@@ -149,10 +149,10 @@ export async function testWithReporter(reporter: Reporter, filter = '', mode: Te
 					// run
 					let proc = spawn('wasmtime', [
 						'--max-wasm-stack=2000000',
-                        '--enable-cranelift-nan-canonicalization',
-                        '--wasm-features',
-                        'multi-memory,bulk-memory',
-						wasmFile
+						'--enable-cranelift-nan-canonicalization',
+						'--wasm-features',
+						'multi-memory,bulk-memory',
+						wasmFile,
 					]);
 					await pipeMMF(proc, mmf);
 				}).finally(() => {


### PR DESCRIPTION
This PR adds support for running WASI unit tests which include [stable regions](https://forum.dfinity.org/t/motoko-stable-regions/19182).

Implementation for `mo-test`: https://github.com/dfinity/motoko-dev-server/pull/54.

Depends on https://github.com/dfinity/motoko/pull/4256. We might make a few adjustments before this is ready to merge.
