### PR TITLE
GitHub dep name conflict

### DIFF
--- a/backend/main/PackagePublisher.mo
+++ b/backend/main/PackagePublisher.mo
@@ -103,6 +103,9 @@ module {
 				if (dep.repo.size() == 0 and registry.getPackageConfig(PackageUtils.getDepName(dep.name), dep.version) == null) {
 					return #err("Dependency " # packageId # " not found in registry");
 				};
+				if (dep.repo.size() != 0 and registry.getPackageOwner(PackageUtils.getDepName(dep.name)) != null) {
+					return #err("GitHub dependency `" # dep.name # "` conflicts with an existing package in the Mops registry. Please change the dependency name in mops.toml file.");
+				};
 			};
 
 			// check devDependencies

--- a/blog/blog/2024-07-30/index.md
+++ b/blog/blog/2024-07-30/index.md
@@ -5,6 +5,15 @@ authors: [zen]
 tags: []
 ---
 
+
+### Summary
+- First Mops blog post
+- Common nav bar
+- Mops CLI updates
+- GitHub Action update
+- Documentation updates
+- GitHub dependency name restrictions
+
 <!-- truncate -->
 
 ## Mops blog
@@ -22,11 +31,15 @@ Further Mops updates will be posted here. Previous updates can be found in the [
 Added a common nav bar to all subdomains for easier navigation.
 
 ## Mops CLI updates
+
 **`0.45.0`** by [@ZenVoich](https://github.com/ZenVoich)
 - Updated npm dependencies
 - Added `--no-install` flag to `mops sources` command
+- Added `--verbose` flag to `mops publish` command
 - Added support for [dependency version pinning](https://docs.mops.one/dependency-version-pinning)
 - Suppress hashing tool detecting error in `moc-wrapper.sh` on Linux
+- Fixed `moc-wrapper` error when no `.mops` folder exists
+- Fixed cache folder delete on github install error
 
 ## GitHub Action update
 
@@ -46,6 +59,24 @@ no changes are required from your side.
 
 ## Documentation updates
 
-- Added a new page [How dependency resolution works](https://docs.mops.one/how-dependency-resolution-works) (by [@ZenVoich](https://github.com/ZenVoich))
-- Added a new page [How to version a package](https://docs.mops.one/how-to-version-a-package) (by [@ZenVoich](https://github.com/ZenVoich))
-- Added a new page [Dependency version pinning](https://docs.mops.one/dependency-version-pinning) (by [@ZenVoich](https://github.com/ZenVoich))
+(by [@ZenVoich](https://github.com/ZenVoich))
+
+- Added a new page [How dependency resolution works](https://docs.mops.one/how-dependency-resolution-works)
+- Added a new page [How to version a package](https://docs.mops.one/how-to-version-a-package)
+- Added a new page [Dependency version pinning](https://docs.mops.one/dependency-version-pinning)
+
+## GitHub dependency name restrictions
+
+(by [@ZenVoich](https://github.com/ZenVoich))
+
+Now you cannot publish a package with a github dependency whose name is already taken in the Mops registry.
+
+This helps to avoid confusion when resolving packages with the same name from different sources, because they can be completely different packages.
+
+Example:
+```toml
+[dependencies]
+base = "https://github.com/dfinity/motoko-base#moc-0.12.0" # bad
+base_gh_0_12_0 = "https://github.com/dfinity/motoko-base#moc-0.12.0" # ok
+any-other-name = "https://github.com/dfinity/motoko-base#moc-0.12.0" # ok
+```

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Mops CLI Changelog
 
 ## unreleased
+
+## 0.45.0
 - Updated npm dependencies
 - Added `--no-install` flag to `mops sources` command
+- Added `--verbose` flag to `mops publish` command
 - Added support for [dependency version pinning](https://docs.mops.one/dependency-version-pinning)
 - Suppress hashing tool detecting error in `moc-wrapper.sh` on Linux
+- Fixed `moc-wrapper` error when no `.mops` folder exists
+- Fixed cache folder delete on github install error
 
 ## 0.44.1
 - Fixed fallback to dfx moc if there is no mops.toml

--- a/cli/bin/moc-wrapper.sh
+++ b/cli/bin/moc-wrapper.sh
@@ -31,7 +31,7 @@ else
       echo -n $mocPath > "$cached"
     fi;
   else
-    mkdir -p $(dirname $cached)
+    mkdir -p "$(dirname $cached)"
     mocPath="$(mops toolchain bin moc --fallback)"
     echo -n $mocPath > "$cached"
   fi;

--- a/cli/bin/moc-wrapper.sh
+++ b/cli/bin/moc-wrapper.sh
@@ -31,6 +31,7 @@ else
       echo -n $mocPath > "$cached"
     fi;
   else
+    mkdir -p $(dirname $cached)
     mocPath="$(mops toolchain bin moc --fallback)"
     echo -n $mocPath > "$cached"
   fi;

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -125,6 +125,7 @@ program
 	.option('--no-docs', 'Do not generate docs')
 	.option('--no-test', 'Do not run tests')
 	.option('--no-bench', 'Do not run benchmarks')
+	.option('--verbose')
 	.action(async (options) => {
 		if (!checkConfigFile()) {
 			process.exit(1);

--- a/cli/commands/publish.ts
+++ b/cli/commands/publish.ts
@@ -18,7 +18,7 @@ import {SilentReporter} from './test/reporters/silent-reporter.js';
 import {findChangelogEntry} from '../helpers/find-changelog-entry.js';
 import {bench} from './bench.js';
 
-export async function publish(options : {docs ?: boolean, test ?: boolean, bench ?: boolean} = {}) {
+export async function publish(options : {docs ?: boolean, test ?: boolean, bench ?: boolean, verbose ?: boolean} = {}) {
 	if (!checkConfigFile()) {
 		return;
 	}
@@ -222,6 +222,11 @@ export async function publish(options : {docs ?: boolean, test ?: boolean, bench
 	files = [...files, ...defaultFiles];
 	files = globbySync([...files, ...defaultFiles]);
 
+	if (options.verbose) {
+		console.log('Files:');
+		console.log(files.map((file) => '  ' + file).join('\n'));
+	}
+
 	// generate docs
 	let docsFile = path.join(rootDir, '.mops/.docs/docs.tgz');
 	if (options.docs) {
@@ -308,7 +313,7 @@ export async function publish(options : {docs ?: boolean, test ?: boolean, bench
 	let publishing = await actor.startPublish(backendPkgConfig);
 	if ('err' in publishing) {
 		console.log(chalk.red('Error: ') + publishing.err);
-		return;
+		process.exit(1);
 	}
 	let puiblishingId = publishing.ok;
 
@@ -347,7 +352,7 @@ export async function publish(options : {docs ?: boolean, test ?: boolean, bench
 		let res = await actor.startFileUpload(puiblishingId, file, BigInt(chunkCount), firstChunk);
 		if ('err' in res) {
 			console.log(chalk.red('Error: ') + res.err);
-			return;
+			process.exit(1);
 		}
 		let fileId = res.ok;
 
@@ -357,7 +362,7 @@ export async function publish(options : {docs ?: boolean, test ?: boolean, bench
 			let res = await actor.uploadFileChunk(puiblishingId, fileId, BigInt(i), chunk);
 			if ('err' in res) {
 				console.log(chalk.red('Error: ') + res.err);
-				return;
+				process.exit(1);
 			}
 		}
 	});
@@ -371,7 +376,7 @@ export async function publish(options : {docs ?: boolean, test ?: boolean, bench
 	let res = await actor.finishPublish(puiblishingId);
 	if ('err' in res) {
 		console.log(chalk.red('Error: ') + res.err);
-		return;
+		process.exit(1);
 	}
 
 	console.log(chalk.green('Published ') + `${config.package.name}@${config.package.version}`);

--- a/cli/vessel.ts
+++ b/cli/vessel.ts
@@ -171,7 +171,7 @@ export const installFromGithub = async (name : string, repo : string, {verbose =
 			await downloadFromGithub(repo, cacheDir, progress);
 		}
 		catch (err) {
-			deleteSync([cacheDir]);
+			deleteSync([cacheDir], {force: true});
 			process.exit(1);
 		}
 	}

--- a/dfx.json
+++ b/dfx.json
@@ -65,7 +65,7 @@
 			"packtool": "mops sources"
 		}
 	},
-	"dfx": "0.20.2",
+	"dfx": "0.21.0",
 	"networks": {
 		"staging": {
 			"type": "persistent",

--- a/docs/docs/cli/2-publish/01-mops-publish.md
+++ b/docs/docs/cli/2-publish/01-mops-publish.md
@@ -33,3 +33,5 @@ You can also view the diff of the benchmark results between the current version 
 `--no-test` - Do not run tests
 
 `--no-bench` - Do not run benchmarks
+
+`--verbose` - Verbose output (print file names to be uploaded)

--- a/frontend/components/package/Package.svelte
+++ b/frontend/components/package/Package.svelte
@@ -227,6 +227,7 @@
 									<div class="packages">
 										{#each githubDeps as dep}
 											<div class="github-dep">
+												<div class="github-dep-name">{dep.name}</div>
 												<a class="github-dep-repo" href="{dep.repo}" target="_blank">
 													<img class="github-icon" src="{githubImg}" alt="GitHub logo" loading="lazy" />
 													<div>{dep.repo.replace(/https?:\/\/(www\.)?(github\.com\/)?/, '').split('#')[0]}</div>
@@ -401,6 +402,10 @@
 	.github-dep-repo {
 		display: flex;
 		gap: 5px;
+		white-space: nowrap;
+	}
+
+	.github-dep-name {
 		white-space: nowrap;
 	}
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"decl:cli": "dfx generate main && dfx generate bench",
 		"decl:frontend": "cp -r cli/declarations frontend",
 		"deploy": "dfx deploy --no-wallet --identity ${IDENTITY:-default} --network ${DFX_NETWORK:-local}",
-		"deploy-local": "NODE_ENV=development dfx deploy main --no-wallet --identity default",
+		"deploy-local": "NODE_ENV=development dfx deploy --identity default --no-wallet main",
 		"deploy-staging": "NODE_ENV=production IDENTITY=mops DFX_NETWORK=staging npm run deploy",
 		"deploy-ic": "NODE_ENV=production IDENTITY=mops DFX_NETWORK=ic npm run deploy",
 		"deploy:main": "NODE_ENV=development IDENTITY=default DFX_NETWORK=local npm run deploy main",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new validation for package dependencies to prevent conflicts with existing packages in the Mops registry.
	- Added a new summary section to the Mops blog post with key updates and enhancements.
	- Updated Mops CLI to version `0.45.0`, including new command-line flags for better user control (`--no-install` and `--verbose`).
	- Enhanced documentation on dependency resolution and versioning.
	- Improved user interface by displaying GitHub dependency names in the package component.

- **Bug Fixes**
	- Enhanced error handling in the `moc-wrapper` script for better stability.
	- Fixed issues related to `.mops` folder absence during operations.

- **Documentation**
	- Added comprehensive documentation for new CLI commands and options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->