### PR TITLE
Speed up install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 1
       matrix:
         moc-version: [0.11.1]
-        mops-version: [ic-mops@1.0.0, ./cli/dist]
+        mops-version: [ic-mops@1.1.0-pre.0, ./cli/dist]
         node-version: [20]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 3
       fail-fast: false
       matrix:
-        mops-version: [./cli/dist, ic-mops@1.0.0, "https://cli.mops.one/versions/latest.tgz"]
+        mops-version: [./cli/dist, ic-mops@1.0.0, ic-mops@1.1.0-pre.0, "https://cli.mops.one/versions/latest.tgz"]
         moc-version: [0.11.1]
         node-version: [18, 20, 22]
         runner: [ubuntu-latest, macos-latest]

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -162,7 +162,7 @@ program
 			process.exit(1);
 		}
 		if (options.install) {
-			await installAll({silent: true, lock: 'ignore', threads: 6});
+			await installAll({silent: true, lock: 'ignore', threads: 6, installFromLockFile: true});
 		}
 		await toolchain.ensureToolchainInited({strict: false});
 		let sourcesArr = await sources(options);
@@ -206,7 +206,7 @@ program
 	.option('-w, --watch', 'Enable watch mode')
 	.action(async (filter, options) => {
 		checkConfigFile(true);
-		await installAll({silent: true, lock: 'ignore'});
+		await installAll({silent: true, lock: 'ignore', installFromLockFile: true});
 		await test(filter, options);
 	});
 
@@ -222,7 +222,7 @@ program
 	.addOption(new Option('--verbose', 'Show more information'))
 	.action(async (filter, options) => {
 		checkConfigFile(true);
-		await installAll({silent: true, lock: 'ignore'});
+		await installAll({silent: true, lock: 'ignore', installFromLockFile: true});
 		await bench(filter, options);
 	});
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -89,6 +89,7 @@ program
 	.command('install')
 	.alias('i')
 	.description('Install all dependencies specified in mops.toml')
+	.option('--no-toolchain', 'Do not install toolchain')
 	.option('--verbose')
 	.addOption(new Option('--lock <action>', 'Lockfile action').choices(['check', 'update', 'ignore']))
 	.action(async (options) => {
@@ -101,10 +102,15 @@ program
 			return;
 		}
 
-		await toolchain.ensureToolchainInited({strict: false});
+		if (options.toolchain) {
+			await toolchain.ensureToolchainInited({strict: false});
+		}
 
 		let ok = await installAll(options);
-		await toolchain.installAll(options);
+
+		if (options.toolchain) {
+			await toolchain.installAll(options);
+		}
 
 		// check conflicts
 		await resolvePackages({conflicts: 'warning'});

--- a/cli/commands/install/install-all.ts
+++ b/cli/commands/install/install-all.ts
@@ -1,8 +1,8 @@
 import process from 'node:process';
 import chalk from 'chalk';
 import {createLogUpdate} from 'log-update';
-import {checkConfigFile, readConfig} from '../../mops.js';
-import {checkIntegrity} from '../../integrity.js';
+import {checkConfigFile, parseDepValue, readConfig} from '../../mops.js';
+import {checkIntegrity, checkLockFileLight, readLockFile} from '../../integrity.js';
 import {installDeps} from './install-deps.js';
 import {checkRequirements} from '../../check-requirements.js';
 import {syncLocalCache} from './sync-local-cache.js';
@@ -13,9 +13,10 @@ type InstallAllOptions = {
 	silent ?: boolean;
 	lock ?: 'check' | 'update' | 'ignore';
 	threads ?: number;
+	installFromLockFile ?: boolean;
 }
 
-export async function installAll({verbose = false, silent = false, threads, lock} : InstallAllOptions = {}) : Promise<boolean> {
+export async function installAll({verbose = false, silent = false, threads, lock, installFromLockFile} : InstallAllOptions = {}) : Promise<boolean> {
 	if (!checkConfigFile()) {
 		return false;
 	}
@@ -24,11 +25,32 @@ export async function installAll({verbose = false, silent = false, threads, lock
 	let deps = Object.values(config.dependencies || {});
 	let devDeps = Object.values(config['dev-dependencies'] || {});
 	let allDeps = [...deps, ...devDeps];
+	let installedFromLockFile = false;
 
-	let ok = await installDeps(allDeps, {silent, verbose, threads});
-	if (!ok) {
-		return false;
+	// install from lock file to avoid installing intermediate dependencies
+	if ((lock !== 'ignore' || installFromLockFile) && checkLockFileLight()) {
+		let lockFileJson = readLockFile();
+
+		if (lockFileJson && lockFileJson.version === 3) {
+			verbose && console.log('Installing from lock file...');
+			installedFromLockFile = true;
+			let deps = Object.entries(lockFileJson.deps).map(([name, version]) => {
+				return parseDepValue(name, version);
+			});
+			let ok = await installDeps(deps, {silent, verbose, threads, ignoreTransitive: true});
+			if (!ok) {
+				return false;
+			}
+		}
 	}
+
+	if (!installedFromLockFile) {
+		let ok = await installDeps(allDeps, {silent, verbose, threads});
+		if (!ok) {
+			return false;
+		}
+	}
+
 
 	let logUpdate = createLogUpdate(process.stdout, {showCursor: true});
 

--- a/cli/commands/install/install-all.ts
+++ b/cli/commands/install/install-all.ts
@@ -34,10 +34,10 @@ export async function installAll({verbose = false, silent = false, threads, lock
 		if (lockFileJson && lockFileJson.version === 3) {
 			verbose && console.log('Installing from lock file...');
 			installedFromLockFile = true;
-			let deps = Object.entries(lockFileJson.deps).map(([name, version]) => {
+			let lockedDeps = Object.entries(lockFileJson.deps).map(([name, version]) => {
 				return parseDepValue(name, version);
 			});
-			let ok = await installDeps(deps, {silent, verbose, threads, ignoreTransitive: true});
+			let ok = await installDeps(lockedDeps, {silent, verbose, threads, ignoreTransitive: true});
 			if (!ok) {
 				return false;
 			}

--- a/cli/commands/install/install-dep.ts
+++ b/cli/commands/install/install-dep.ts
@@ -9,13 +9,14 @@ type InstallDepOptions = {
 	verbose ?: boolean;
 	silent ?: boolean;
 	threads ?: number;
+	ignoreTransitive ?: boolean;
 };
 
 // install dependency
 // returns false if failed
-export async function installDep(dep : Dependency, {verbose, silent, threads} : InstallDepOptions = {}, parentPkgPath ?: string) : Promise<boolean> {
+export async function installDep(dep : Dependency, {verbose, silent, threads, ignoreTransitive} : InstallDepOptions = {}, parentPkgPath ?: string) : Promise<boolean> {
 	if (dep.repo) {
-		await installFromGithub(dep.name, dep.repo, {silent, verbose});
+		await installFromGithub(dep.name, dep.repo, {silent, verbose, ignoreTransitive});
 		return true;
 	}
 	else if (dep.path) {
@@ -24,10 +25,10 @@ export async function installDep(dep : Dependency, {verbose, silent, threads} : 
 		if (parentPkgPath) {
 			depPath = path.resolve(parentPkgPath, dep.path);
 		}
-		return installLocalDep(dep.name, depPath, {silent, verbose});
+		return installLocalDep(dep.name, depPath, {silent, verbose, ignoreTransitive});
 	}
 	else if (dep.version) {
-		return installMopsDep(dep.name, dep.version, {silent, verbose, threads});
+		return installMopsDep(dep.name, dep.version, {silent, verbose, threads, ignoreTransitive});
 	}
 
 	return true;

--- a/cli/commands/install/install-deps.ts
+++ b/cli/commands/install/install-deps.ts
@@ -5,16 +5,17 @@ type InstallDepsOptions = {
 	verbose ?: boolean;
 	silent ?: boolean;
 	threads ?: number;
+	ignoreTransitive ?: boolean;
 };
 
 // install all dependencies
 // returns actual installed dependencies
 // returns false if failed
-export async function installDeps(deps : Dependency[], {verbose, silent, threads} : InstallDepsOptions = {}, parentPkgPath ?: string) : Promise<boolean> {
+export async function installDeps(deps : Dependency[], {verbose, silent, threads, ignoreTransitive} : InstallDepsOptions = {}, parentPkgPath ?: string) : Promise<boolean> {
 	let ok = true;
 
 	for (const dep of deps) {
-		let res = await installDep(dep, {verbose, silent, threads}, parentPkgPath);
+		let res = await installDep(dep, {verbose, silent, threads, ignoreTransitive}, parentPkgPath);
 		if (!res) {
 			ok = false;
 		}

--- a/cli/commands/install/install-local-dep.ts
+++ b/cli/commands/install/install-local-dep.ts
@@ -7,11 +7,12 @@ import {installDeps} from './install-deps.js';
 type InstallLocalDepOptions = {
 	verbose ?: boolean;
 	silent ?: boolean;
+	ignoreTransitive ?: boolean;
 };
 
 // skip install and just find non-local dependencies to install
 // pkgPath should be relative to the current root dir or absolute
-export async function installLocalDep(pkg : string, pkgPath = '', {verbose, silent} : InstallLocalDepOptions = {}) : Promise<boolean> {
+export async function installLocalDep(pkg : string, pkgPath = '', {verbose, silent, ignoreTransitive} : InstallLocalDepOptions = {}) : Promise<boolean> {
 	if (!silent) {
 		let logUpdate = createLogUpdate(process.stdout, {showCursor: true});
 		logUpdate(`Local dependency ${pkg} = "${pkgPath}"`);
@@ -25,7 +26,12 @@ export async function installLocalDep(pkg : string, pkgPath = '', {verbose, sile
 	}
 
 	// install dependencies
-	let dir = path.resolve(getRootDir(), pkgPath);
-	let config = readConfig(path.join(dir, 'mops.toml'));
-	return installDeps(Object.values(config.dependencies || {}), {silent, verbose}, pkgPath);
+	if (!ignoreTransitive) {
+		let dir = path.resolve(getRootDir(), pkgPath);
+		let config = readConfig(path.join(dir, 'mops.toml'));
+		return installDeps(Object.values(config.dependencies || {}), {silent, verbose}, pkgPath);
+	}
+	else {
+		return true;
+	}
 }

--- a/cli/commands/install/install-mops-dep.ts
+++ b/cli/commands/install/install-mops-dep.ts
@@ -19,9 +19,10 @@ type InstallMopsDepOptions = {
 	silent ?: boolean;
 	dep ?: boolean;
 	threads ?: number;
+	ignoreTransitive ?: boolean;
 };
 
-export async function installMopsDep(pkg : string, version = '', {verbose, silent, dep, threads} : InstallMopsDepOptions = {}) : Promise<boolean> {
+export async function installMopsDep(pkg : string, version = '', {verbose, silent, dep, threads, ignoreTransitive} : InstallMopsDepOptions = {}) : Promise<boolean> {
 	threads = threads || 12;
 	let depName = getDepName(pkg);
 
@@ -113,11 +114,13 @@ export async function installMopsDep(pkg : string, version = '', {verbose, silen
 	}
 
 	// install dependencies
-	let config = readConfig(path.join(cacheDir, 'mops.toml'));
-	let res = await installDeps(Object.values(config.dependencies || {}), {silent, verbose});
+	if (!ignoreTransitive) {
+		let config = readConfig(path.join(cacheDir, 'mops.toml'));
+		let res = await installDeps(Object.values(config.dependencies || {}), {silent, verbose});
 
-	if (!res) {
-		return false;
+		if (!res) {
+			return false;
+		}
 	}
 
 	return true;

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -167,6 +167,7 @@ export async function updateLockFile() {
 
 // compare hashes of local files with hashes from the lock file
 export async function checkLockFile(force = false) {
+	let supportedVersions = [1, 2, 3];
 	let rootDir = getRootDir();
 	let lockFile = path.join(rootDir, 'mops.lock');
 
@@ -183,9 +184,9 @@ export async function checkLockFile(force = false) {
 	let packageIds = await getResolvedMopsPackageIds();
 
 	// check lock file version
-	if (lockFileJsonGeneric.version !== 1 && lockFileJsonGeneric.version !== 2 && lockFileJsonGeneric.version !== 3) {
+	if (!supportedVersions.includes(lockFileJsonGeneric.version)) {
 		console.error('Integrity check failed');
-		console.error(`Invalid lock file version: ${lockFileJsonGeneric.version}. Supported versions: 1, 2, 3`);
+		console.error(`Invalid lock file version: ${lockFileJsonGeneric.version}. Supported versions: ${supportedVersions.join(', ')}`);
 		process.exit(1);
 	}
 

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -185,7 +185,7 @@ export async function checkLockFile(force = false) {
 	// check lock file version
 	if (lockFileJsonGeneric.version !== 1 && lockFileJsonGeneric.version !== 2 && lockFileJsonGeneric.version !== 3) {
 		console.error('Integrity check failed');
-		console.error(`Invalid lock file version: ${lockFileJsonGeneric.version}. Supported versions: 1`);
+		console.error(`Invalid lock file version: ${lockFileJsonGeneric.version}. Supported versions: 1, 2, 3`);
 		process.exit(1);
 	}
 

--- a/cli/resolve-packages.ts
+++ b/cli/resolve-packages.ts
@@ -6,10 +6,19 @@ import {VesselConfig, readVesselConfig} from './vessel.js';
 import {Config, Dependency} from './types.js';
 import {getDepCacheDir, getDepCacheName} from './cache.js';
 import {getPackageId} from './helpers/get-package-id.js';
+import {checkLockFileLight, readLockFile} from './integrity.js';
 
 export async function resolvePackages({conflicts = 'ignore' as 'warning' | 'error' | 'ignore'} = {}) : Promise<Record<string, string>> {
 	if (!checkConfigFile()) {
 		return {};
+	}
+
+	if (checkLockFileLight()) {
+		let lockFileJson = readLockFile();
+
+		if (lockFileJson && lockFileJson.version === 3) {
+			return lockFileJson.deps;
+		}
 	}
 
 	let rootDir = getRootDir();

--- a/cli/templates/mops-test.yml
+++ b/cli/templates/mops-test.yml
@@ -14,9 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ZenVoich/setup-mops@v1
+        with:
+          mops-version: 1
 
-      - name: make sure moc is installed
-        run: mops toolchain bin moc || mops toolchain use moc latest
+      - name: install mops packages
+        run: mops install
 
       - name: run tests
         run: mops test

--- a/cli/vessel.ts
+++ b/cli/vessel.ts
@@ -149,7 +149,7 @@ export const downloadFromGithub = async (repo : string, dest : string, onProgres
 	return promise;
 };
 
-export const installFromGithub = async (name : string, repo : string, {verbose = false, dep = false, silent = false} = {}) => {
+export const installFromGithub = async (name : string, repo : string, {verbose = false, dep = false, silent = false, ignoreTransitive = false} = {}) => {
 	let cacheName = getGithubDepCacheName(name, repo);
 	let cacheDir = getDepCacheDir(cacheName);
 
@@ -181,6 +181,10 @@ export const installFromGithub = async (name : string, repo : string, {verbose =
 	}
 	else {
 		logUpdate.clear();
+	}
+
+	if (ignoreTransitive) {
+		return;
 	}
 
 	const config = await readVesselConfig(cacheDir, {silent});

--- a/mops.lock
+++ b/mops.lock
@@ -1,6 +1,28 @@
 {
-  "version": 2,
+  "version": 3,
   "mopsTomlDepsHash": "a39c7d6e2730ad672c0b1b1769183d7936cf01a183a468578a672322b86e5057",
+  "deps": {
+    "base": "0.12.1",
+    "time-consts": "1.0.1",
+    "map": "9.0.1",
+    "ic": "1.0.1",
+    "backup": "3.0.0",
+    "linked-list": "0.1.0",
+    "http-types": "1.0.1",
+    "motoko-datetime": "https://github.com/ByronBecker/motoko-datetime#v0.1.1@bda6139ec56d36731326727ae28510f1e1843f27",
+    "memory-region": "0.1.1",
+    "stableheapbtreemap": "1.3.0",
+    "matchers": "https://github.com/kritzcreek/motoko-matchers#v1.3.0",
+    "fuzz": "0.2.1",
+    "sha2": "0.1.0",
+    "vector": "0.4.0",
+    "datetime": "0.3.0",
+    "xtended-text": "0.3.0",
+    "xtended-numbers": "0.3.1",
+    "principal-ext": "0.1.0",
+    "test": "2.0.0",
+    "bench": "1.0.0"
+  },
   "hashes": {
     "base@0.12.1": {
       "base@0.12.1/mops.toml": "118b3be79becd448f8e448734d8319c162f2de3ab86995fa7fe40afce207f145",


### PR DESCRIPTION
- Lockfile v3
- Faster install from lockfile
- `mops install --no-toolchain`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a `--no-toolchain` option in the CLI `install` command, allowing users to skip toolchain installation.
  - Enhanced installation flexibility with new parameters to control transitive dependency handling across various commands.

- **Improvements**
  - Updated the lock file management to support a new version with improved integrity checks and dependency tracking.
  - Improved the dependency parsing logic for better modularity and readability.

- **Bug Fixes**
  - Fixed installation behavior to utilize lock files for resolving dependencies when applicable.

These changes enhance user experience by providing more control over installation processes and improving dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->