### PR TITLE
Update 02-mops-toolchain-init.md

### DIFF
--- a/docs/docs/cli/5-toolchain/02-mops-toolchain-init.md
+++ b/docs/docs/cli/5-toolchain/02-mops-toolchain-init.md
@@ -19,7 +19,7 @@ It will update your `.bashrc`/`.zshrc` file to set `DFX_MOC_PATH` to the `moc-wr
 So when you build your project with `dfx`, it will use `moc` version specified in `mops.toml` file. If `moc` version is not specified, it will use default `moc` version that comes with `dfx`.
 
 :::info
-In CI environment, this command runs automatically when you run `mops install` or `mops toolhcain use`.
+In CI environment, this command runs automatically when you run `mops install` or `mops toolchain use`.
 
 So no need to run it manually in GitHub Actions.
 :::


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected typographical error in the `mops toolchain init` command documentation.
	- Clarified that the command runs automatically in CI environments during `mops install` or `mops toolchain use`.
	- Instructions for undoing changes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->