### PR TITLE
[cli] compile benchmarks with `--release` flag 

### DIFF
--- a/cli/commands/watch/parseDfxJson.ts
+++ b/cli/commands/watch/parseDfxJson.ts
@@ -5,6 +5,7 @@ import {getRootDir} from '../../mops.js';
 type DfxConfig = {
 	$schema : string;
 	version : number;
+	profile : 'Debug' | 'Release';
 	canisters : {
 		[key : string] : {
 			type : 'motoko' | 'assets';
@@ -41,7 +42,7 @@ type DfxConfig = {
 	};
 };
 
-function readDfxJson() : DfxConfig | Record<string, never> {
+export function readDfxJson() : DfxConfig | Record<string, never> {
 	let dfxJsonPath = path.resolve(getRootDir(), 'dfx.json');
 	if (!existsSync(dfxJsonPath)) {
 		return {};


### PR DESCRIPTION
fixes #270 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option allowing users to choose between "Debug" and "Release" build profiles.
	- Enhanced the benchmarking and configuration processes with improved flexibility in specifying and retrieving build profile settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->