### PR TITLE
Fix regression in `mops bench` without `dfx.json` file

### DIFF
--- a/cli/commands/bench.ts
+++ b/cli/commands/bench.ts
@@ -67,7 +67,7 @@ export async function bench(filter = '', optionsArg : Partial<BenchOptions> = {}
 		compare: false,
 		verbose: false,
 		silent: false,
-		profile: dfxJson.profile || 'Release',
+		profile: dfxJson?.profile || 'Release',
 	};
 
 	let options : BenchOptions = {...defaultOptions, ...optionsArg};


### PR DESCRIPTION
Resolves https://github.com/ZenVoich/mops/issues/276.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the CLI command's handling of profile configurations to prevent potential runtime issues by ensuring default values are applied when configuration data is absent.
  
- **Chores**
  - Made minor formatting adjustments for enhanced code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->