### PR TITLE
[cli] feat: support multiple package versions

### DIFF
--- a/cli/check-requirements.ts
+++ b/cli/check-requirements.ts
@@ -21,8 +21,8 @@ export async function checkRequirements({verbose = false} = {}) {
 	let highestRequiredMocPkgId = '';
 	let rootDir = getRootDir();
 
-	let resolvedPackages = await resolvePackages();
-	for (let [name, version] of Object.entries(resolvedPackages)) {
+	let resolved = await resolvePackages();
+	for (let [name, version] of Object.entries(resolved.packages)) {
 		if (getDependencyType(version) === 'mops') {
 			let pkgId = getPackageId(name, version);
 			let depConfig = readConfig(path.join(rootDir, '.mops', pkgId, 'mops.toml'));

--- a/cli/commands/install/sync-local-cache.ts
+++ b/cli/commands/install/sync-local-cache.ts
@@ -5,14 +5,14 @@ import {getDependencyType, getRootDir} from '../../mops.js';
 import {resolvePackages} from '../../resolve-packages.js';
 
 export async function syncLocalCache({verbose = false} = {}) : Promise<Record<string, string>> {
-	let resolvedPackages = await resolvePackages();
+	let resolved = await resolvePackages();
 	let rootDir = getRootDir();
 
 	verbose && console.log('Syncing local cache...');
 
 	let installedDeps : Record<string, string> = {};
 
-	await Promise.all(Object.entries(resolvedPackages).map(([name, value]) => {
+	await Promise.all(Object.entries(resolved.packages).map(([name, value]) => {
 		let depType = getDependencyType(value);
 
 		if (depType === 'mops' || depType === 'github') {


### PR DESCRIPTION
Work in progress!

This PR is an experiment for supporting more than one version for the same package by passing `--override` flags (see https://github.com/dfinity/motoko/pull/5124). 

**Progress:**
* [x] Add new lockfile format with overrides
* [ ] Modify `resolvePackages()` return value to include overrides or alternate versions (partially implemented)
* [ ] Refactor usages of `resolvePackages()` which currently assume only one version per package

This will require a more significant refactor than what is currently implemented. It could also make sense to change `resolvePackage` to return a list of package versions and then resolve the overrides in `sources.ts`. Still working on this but wanted to open a PR in the meantime.