### PR TITLE
feat: enable `memory64` for `wasi` testing

### DIFF
--- a/cli/commands/test/test.ts
+++ b/cli/commands/test/test.ts
@@ -289,6 +289,7 @@ export async function testWithReporter(reporterName : ReporterName | Reporter | 
 							'-C', 'cache=n',
 							'-W', 'bulk-memory',
 							'-W', 'multi-memory',
+							'-W', 'memory64',
 							'-W', 'max-wasm-stack=4000000',
 							'-W', 'nan-canonicalization=y',
 							wasmFile,


### PR DESCRIPTION
Poor-man's version of #299, but this should work for now.

_Motivation_: Starting with version > 0.14.4 of `moc` the 64-bit mode is the default, so `mops` tests should allow it.

https://github.com/bytecodealliance/wasmtime/blob/release-14.0.0/RELEASES.md#1400 is the minimum and supports `memory64`, so we are safe.