### PR TITLE
[cli] experiment: refactor/optimize `mops toolchain bin` command

### DIFF
--- a/cli/commands/toolchain/index.ts
+++ b/cli/commands/toolchain/index.ts
@@ -44,8 +44,7 @@ async function ensureToolchainInited({strict = true} = {}) {
 	}
 
 	try {
-		let res = execSync('which moc-wrapper').toString().trim();
-		if (res && process.env.DFX_MOC_PATH === 'moc-wrapper') {
+		if (process.env.DFX_MOC_PATH === 'moc-wrapper' && execSync('which moc-wrapper').toString().trim()) {
 			return true;
 		}
 	}

--- a/cli/commands/toolchain/moc.ts
+++ b/cli/commands/toolchain/moc.ts
@@ -20,7 +20,7 @@ export let getReleases = async () => {
 
 export let isCached = (version : string) => {
 	let dir = path.join(cacheDir, version);
-	return fs.existsSync(dir) && fs.existsSync(path.join(dir, 'moc'));
+	return fs.existsSync(path.join(dir, 'moc'));
 };
 
 export let download = async (version : string, {silent = false, verbose = false} = {}) => {
@@ -39,22 +39,23 @@ export let download = async (version : string, {silent = false, verbose = false}
 		return;
 	}
 
+	let semver = new SemVer(version);
 	let url;
-	if (new SemVer(version).compare(new SemVer('0.14.6')) >= 0) {
+	if (semver.compare(new SemVer('0.14.6')) >= 0) {
 		let platfrom = process.platform == 'darwin' ? 'Darwin' : 'Linux';
 		let arch = process.arch.startsWith('arm')
 			? (process.platform == 'darwin' ? 'arm64' : 'aarch64')
 			: 'x86_64';
 		url = `https://github.com/dfinity/motoko/releases/download/${version}/motoko-${platfrom}-${arch}-${version}.tar.gz`;
 	}
-	else if (new SemVer(version).compare(new SemVer('0.9.5')) >= 0) {
+	else if (semver.compare(new SemVer('0.9.5')) >= 0) {
 		let platfrom = process.platform == 'darwin' ? 'Darwin' : 'Linux';
 		let arch = 'x86_64';
 		url = `https://github.com/dfinity/motoko/releases/download/${version}/motoko-${platfrom}-${arch}-${version}.tar.gz`;
 	}
 	else {
-		let platfrom = process.platform == 'darwin' ? 'macos' : 'linux64';
-		url = `https://github.com/dfinity/motoko/releases/download/${version}/motoko-${platfrom}-${version}.tar.gz`;
+		let platform = process.platform == 'darwin' ? 'macos' : 'linux64';
+		url = `https://github.com/dfinity/motoko/releases/download/${version}/motoko-${platform}-${version}.tar.gz`;
 	}
 
 	if (verbose && !silent) {


### PR DESCRIPTION
This PR makes a few minor code changes as an experiment to speed up `mops toolchain bin` and (indirectly) other commands by caching config and reducing file system operations / command executions.

The performance improvement is very minimal (~0.02 seconds on my machine for the [motoko-hamt](https://github.com/christoph-dfinity/motoko-hamt) benchmark), so it's probably better to view this PR as a refactor rather than optimization.

Skipping `ensureToolchainInited()` and `download()` results in another ~0.08 seconds of savings, but this appears negligible compared to the overhead of running the Node.js script. 
