### PR TITLE
[cli] add pinned deps support to `mops update` and `mops outdated`

### DIFF
--- a/cli/commands/add.ts
+++ b/cli/commands/add.ts
@@ -83,7 +83,7 @@ export async function add(name : string, {verbose = false, dev = false, lock} : 
 		}
 
 		pkgDetails = {
-			name: name,
+			name: asName || name,
 			repo: '',
 			version: ver,
 		};

--- a/cli/commands/outdated.ts
+++ b/cli/commands/outdated.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import {checkConfigFile, readConfig} from '../mops.js';
 import {getAvailableUpdates} from './available-updates.js';
+import {getDepName, getDepPinnedVersion} from '../helpers/get-dep-name.js';
 
 export async function outdated() {
 	if (!checkConfigFile()) {
@@ -15,8 +16,14 @@ export async function outdated() {
 	}
 	else {
 		console.log('Available updates:');
+		let allDeps = [...Object.keys(config.dependencies || {}), ...Object.keys(config['dev-dependencies'] || {})];
 		for (let dep of available) {
-			console.log(`${dep[0]} ${chalk.yellow(dep[1])} -> ${chalk.green(dep[2])}`);
+			let name = allDeps.find((d) => {
+				let pinnedVersion = getDepPinnedVersion(d);
+				return getDepName(d) === dep[0] && (!pinnedVersion || dep[1].startsWith(pinnedVersion));
+			}) || dep[0];
+
+			console.log(`${name} ${chalk.yellow(dep[1])} -> ${chalk.green(dep[2])}`);
 		}
 	}
 }

--- a/cli/helpers/get-dep-name.ts
+++ b/cli/helpers/get-dep-name.ts
@@ -1,3 +1,7 @@
 export function getDepName(name : string) : string {
 	return name.split('@')[0] || '';
 }
+
+export function getDepPinnedVersion(name : string) : string {
+	return name.split('@')[1] || '';
+}


### PR DESCRIPTION
fixes #315 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add packages with a custom alias; updates now preserve and use aliases.
  - Outdated list shows the configured alias when available.

- Improvements
  - Update checks respect pinned versions, constraining updates (major/minor/patch) based on the pin level.
  - Smarter version comparison and filtering to avoid proposing updates for hard-pinned dependencies.
  - More accurate detection of dev dependencies during updates for correct install targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->