### PR TITLE
[cli] add support for subheadings in changelog

### DIFF
--- a/cli/helpers/find-changelog-entry.ts
+++ b/cli/helpers/find-changelog-entry.ts
@@ -4,11 +4,12 @@ import {toMarkdown} from 'mdast-util-to-markdown';
 export function findChangelogEntry(changelog : string, version : string) : string {
 	let tree = fromMarkdown(changelog);
 	let found = false;
+	let depth = 0;
 	let nodes = [];
 
 	for (let node of tree.children) {
 		if (found) {
-			if (node.type === 'heading') {
+			if (node.type === 'heading' && node.depth <= depth) {
 				break;
 			}
 			else {
@@ -16,6 +17,7 @@ export function findChangelogEntry(changelog : string, version : string) : strin
 			}
 		}
 		else if (node.type === 'heading' && toMarkdown(node).match(new RegExp(`\\b${version}\\b`))) {
+			depth = node.depth;
 			found = true;
 		}
 	}


### PR DESCRIPTION
This change allows changelog entries to contain subheadings.
It fixes #308

Tested with https://github.com/f0i/hex/blob/main/CHANGELOG.md