### PR TITLE
release: CLI v2.9.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Mops CLI Changelog
 
 ## Next
+
+## 2.9.0
 - Add `mops info <pkg>` command to show detailed package metadata from the registry
 - Add `[lint.extra]` config for applying additional lint rules to specific files via glob patterns
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ic-mops",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ic-mops",
-      "version": "2.8.1",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "2.2.5",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-mops",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "type": "module",
   "bin": {
     "mops": "dist/bin/mops.js",


### PR DESCRIPTION
Release CLI v2.9.0.

Made with [Cursor](https://cursor.com)