### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
-      - uses: dfinity/setup-dfx@main
+      - uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
 
       - uses: ./.github/actions/cache-rust-wasm
 
@@ -111,7 +111,7 @@ jobs:
         with:
           node-version: 22
           cache: "npm"
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - uses: ./.github/actions/cache-rust-wasm
 
       - name: Install npm packages

--- a/.github/workflows/cli-bundle.yml
+++ b/.github/workflows/cli-bundle.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           bun-version: 1.2.17
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
-      - uses: dfinity/setup-dfx@main
+      - uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
       - run: dfx cache install
       - name: Cache mops packages
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/setup-mops.yml
+++ b/.github/workflows/setup-mops.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
-      - uses: dfinity/setup-dfx@main
-      - uses: dfinity/setup-mops@v1
+      - uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
+      - uses: dfinity/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1
         with:
           mops-version: 1.0.0
       - name: Run tests


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `dfinity/setup-dfx@main` -> `dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/setup-dfx/commit/e50c04f104ee4285ec010f10609483cf41e4d365

- `oven-sh/setup-bun@v2` -> `oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0`
  - Version: v2.2.0 | Latest: v2.2.0 | Release age: 27d
  - Commit: https://github.com/oven-sh/setup-bun/commit/0c5077e51419868618aeaa5fe8019c62421857d6

- `oven-sh/setup-bun@v1` -> `oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2`
  - Version: v1.2.2 | Latest: v2.2.0 | Release age: 27d
  - Commit: https://github.com/oven-sh/setup-bun/commit/f4d14e03ff726c06358e5557344e1da148b56cf7

- `dfinity/setup-mops@v1` -> `dfinity/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1`
  - Version: v1.4.1 | Latest: v1.4.1 | Release age: 569d
  - Commit: https://github.com/dfinity/setup-mops/commit/3e94e453352269b34137b5ce49f09a8df81bed7d


### Files modified

- `.github/workflows/ci.yml`
- `.github/workflows/cli-bundle.yml`
- `.github/workflows/mops-test.yml`
- `.github/workflows/setup-mops.yml`