### PR TITLE
release: CLI v2.10.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next
 
+## 2.10.0
+- `mops check` and `mops check-stable` now apply per-canister `[canisters.<name>].args` (previously only `mops build` applied them)
+- `mops check` now accepts canister names as arguments (e.g. `mops check backend`) to check a specific canister
+- `mops check-stable` now works without arguments, checking all canisters with `[check-stable]` configured
+- `mops check-stable` now accepts canister names as arguments (e.g. `mops check-stable backend`)
+
 ## 2.9.0
 - Add `mops info <pkg>` command to show detailed package metadata from the registry
 - Add `[lint.extra]` config for applying additional lint rules to specific files via glob patterns

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ic-mops",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ic-mops",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "2.2.5",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-mops",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "type": "module",
   "bin": {
     "mops": "dist/bin/mops.js",


### PR DESCRIPTION
Release CLI v2.10.0.

Made with [Cursor](https://cursor.com)