### PR TITLE
fix(integrity): dedupe packageIds when counting resolved packages (#506)

### DIFF
--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -267,11 +267,16 @@ export async function checkLockFile(force = false) {
     }
   }
 
-  // check number of packages
-  if (Object.keys(lockFileJson.hashes).length !== packageIds.length) {
+  // check number of packages — packageIds can contain duplicates when
+  // multiple aliases (e.g. `base`, `base@0`, `base@0.16`) resolve to the
+  // same package@version, while lockFileJson.hashes is keyed by packageId
+  // and naturally deduplicated. Compare unique counts to avoid a spurious
+  // mismatch.
+  let uniquePackageIdCount = new Set(packageIds).size;
+  if (Object.keys(lockFileJson.hashes).length !== uniquePackageIdCount) {
     console.error("Integrity check failed");
     console.error(
-      `Mismatched number of resolved packages: ${JSON.stringify(Object.keys(lockFileJson.hashes).length)} vs ${JSON.stringify(packageIds.length)}`,
+      `Mismatched number of resolved packages: ${JSON.stringify(Object.keys(lockFileJson.hashes).length)} vs ${JSON.stringify(uniquePackageIdCount)}`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Fixes #506 — the "Mismatched number of resolved packages N vs M" failure on valid projects that use aliased dependencies.

## Root cause

In [`cli/integrity.ts`](cli/integrity.ts), the count comparison at the end of `checkLockFile()` uses:

```ts
Object.keys(lockFileJson.hashes).length !== packageIds.length
```

- `lockFileJson.hashes` is keyed by `packageId` (`name@version`), naturally deduplicated by the object.
- `packageIds` comes from `resolvePackages()` which retains the alias dependency-table keys (`base`, `base@0`, `base@0.16`) as separate entries. `getPackageId()` collapses them via `getDepName()`, but the resulting array keeps the duplicates.

So any project with aliased deps has a `packageIds.length > hashes.size` gap equal to the number of aliases, and the integrity check fails even when the lockfile is internally consistent.

## Fix

One-liner: dedupe via `new Set(packageIds).size` before comparing. Also added a comment explaining the subtlety so the next person doesn't restore the naive comparison.

## Repro

Covered in #506 (with attached `mops.toml` / `mops.lock`). Short form: any project with `base = "0.16.0"`, `x-client = "0.1.2"`, etc., where transitives introduce alias rows, fails `mops install --lock update` at the final step.

## Test plan

- [ ] `mops install --lock update` on the #506 repro now exits 0 and produces a lockfile that subsequent `--lock check` passes.
- [ ] Existing integrity tests still pass.
- [ ] A negative test: introduce a real mismatch (delete one `hashes` entry) and confirm the check still fails with the same error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)