### PR TITLE
fix: Drop unknown-section/key/requirement guards from `mops publish`

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
-- Fix `mops publish` rejecting `[moc]`, `[canisters]`, `[build]`, and `[lint]` sections in `mops.toml` (#512)
+- `mops publish` no longer rejects unknown `mops.toml` sections, `package.*` keys, or `requirements.*` entries — these typo guards were the only place in the CLI that complained about unknown keys, drifted from the docs/types, and blocked publish on harmless local-only config like `[moc]`, `[canisters]`, `[build]`, and `[lint]` (#512)
 
 ## 2.12.2
 - Fix `mops install` (and any `--lock check` flow) failing with "Mismatched number of resolved packages" when a project's resolved dependencies include multiple aliases (e.g. `base`, `base@0`, `base@0.16`) that pin to the same `name@version`

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
+- Fix `mops publish` rejecting `[moc]`, `[canisters]`, `[build]`, and `[lint]` sections in `mops.toml` (#512)
 
 ## 2.12.2
 - Fix `mops install` (and any `--lock check` flow) failing with "Mismatched number of resolved packages" when a project's resolved dependencies include multiple aliases (e.g. `base`, `base@0`, `base@0.16`) that pin to the same `name@version`

--- a/cli/commands/publish.ts
+++ b/cli/commands/publish.ts
@@ -47,26 +47,6 @@ export async function publish(
 
   console.log(`Publishing ${config.package?.name}@${config.package?.version}`);
 
-  // validate
-  for (let key of Object.keys(config)) {
-    if (
-      ![
-        "package",
-        "dependencies",
-        "dev-dependencies",
-        "toolchain",
-        "requirements",
-        "moc",
-        "canisters",
-        "build",
-        "lint",
-      ].includes(key)
-    ) {
-      console.log(chalk.red("Error: ") + `Unknown config section [${key}]`);
-      process.exit(1);
-    }
-  }
-
   // required fields
   if (!config.package) {
     console.log(
@@ -98,29 +78,6 @@ export async function publish(
       if (!res.ok) {
         return;
       }
-    }
-  }
-
-  let packageKeys = [
-    "name",
-    "version",
-    "keywords",
-    "description",
-    "repository",
-    "documentation",
-    "homepage",
-    "baseDir",
-    "readme",
-    "license",
-    "files",
-    "dfx",
-    "moc",
-    "donation",
-  ];
-  for (let key of Object.keys(config.package)) {
-    if (!packageKeys.includes(key)) {
-      console.log(chalk.red("Error: ") + `Unknown config key 'package.${key}'`);
-      process.exit(1);
     }
   }
 
@@ -224,15 +181,6 @@ export async function publish(
         return;
       }
     }
-  }
-
-  if (config.requirements) {
-    Object.keys(config.requirements).forEach((name) => {
-      if (name !== "moc") {
-        console.log(chalk.red("Error: ") + `Unknown requirement "${name}"`);
-        return;
-      }
-    });
   }
 
   let toBackendDep = (dep: Dependency): DependencyV2 => {

--- a/cli/commands/publish.ts
+++ b/cli/commands/publish.ts
@@ -56,6 +56,10 @@ export async function publish(
         "dev-dependencies",
         "toolchain",
         "requirements",
+        "moc",
+        "canisters",
+        "build",
+        "lint",
       ].includes(key)
     ) {
       console.log(chalk.red("Error: ") + `Unknown config section [${key}]`);


### PR DESCRIPTION
Fixes #512.

`mops publish` rejected `[moc]`, `[canisters]`, `[build]`, and `[lint]` sections in `mops.toml` even though all four are documented and used by other mops commands.

The check was one of three publish-only typo guards (top-level sections, `[package].*` keys, `[requirements].*` keys) — all dropped, because:

- They drifted from the docs/types every time a new section shipped (#512 was the result).
- No other command complains about unknown keys, so typos silently work everywhere except publish.
- The `[requirements]` guard was already broken — `return` inside `forEach` only printed a red message and continued.

Backend `validateConfig.mo` still enforces the real schema (unknown requirements, length caps, "not supported yet" fields, dependency rules), so no real protection is lost. All other publish validations are untouched.

## Test plan

- [ ] `mops publish` succeeds with `[moc]`, `[canisters]`, `[build]`, `[lint]` sections
- [ ] Backend still rejects unknown `[requirements]` entries
- [ ] Other publish validations (local/GitHub deps, disabled `package.*` fields) still fire