### PR TITLE
chore(cli): deprecate `skipIfMissing` in [check-stable]

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
+- Deprecate `skipIfMissing` in `[canisters.<name>.check-stable]`. Behavior is unchanged for now, but `mops check`/`check-stable` print a warning when it is set. For initial deployments, commit a `.most` file at the configured `path` containing an empty actor (`// Version: 1.0.0\nactor { };`) instead — the stable check then runs against an empty baseline.
 
 ## 2.13.1
 - `mops lint` now honors `[canisters.<name>.migrations].check-limit`, skipping trimmed chain migrations so projects with large migration histories lint as fast as they type-check. Pass an explicit filter (`mops lint <name>`) to opt back in for a one-off lint of a trimmed file.

--- a/cli/commands/check-stable.ts
+++ b/cli/commands/check-stable.ts
@@ -39,15 +39,25 @@ export function resolveStablePath(
     return null;
   }
   const stablePath = resolveConfigPath(stableConfig.path);
+  if (stableConfig.skipIfMissing) {
+    console.warn(
+      chalk.yellow(
+        `WARN: \`skipIfMissing\` in [canisters.${canisterName}.check-stable] is deprecated. ` +
+          `Instead, create ${stableConfig.path} with an empty actor:\n` +
+          "  // Version: 1.0.0\n" +
+          "  actor { };",
+      ),
+    );
+  }
   if (!existsSync(stablePath)) {
     if (stableConfig.skipIfMissing) {
       return null;
     }
     cliError(
       `Deployed file not found: ${stablePath} (canister '${canisterName}')\n` +
-        "Set skipIfMissing = true in [canisters." +
-        canisterName +
-        ".check-stable] to skip this check when the file is missing.",
+        `Create ${stableConfig.path} with an empty actor to enable the check:\n` +
+        "  // Version: 1.0.0\n" +
+        "  actor { };",
     );
   }
   return stablePath;

--- a/cli/tests/check.test.ts
+++ b/cli/tests/check.test.ts
@@ -113,19 +113,20 @@ describe("check", () => {
     expect(result.stdout).toMatch(/Stable compatibility check passed/);
   });
 
-  test("deployed: silently skips when file missing and skipIfMissing", async () => {
+  test("deployed: skips when file missing and skipIfMissing, with deprecation warning", async () => {
     const cwd = path.join(import.meta.dirname, "check/deployed-missing-skip");
     const result = await cli(["check"], { cwd });
     expect(result.exitCode).toBe(0);
     expect(result.stdout).not.toMatch(/stable/i);
+    expect(result.stderr).toMatch(/skipIfMissing.*deprecated/);
   });
 
-  test("deployed: errors when file missing without deployedSkipIfFileMissing", async () => {
+  test("deployed: errors when file missing", async () => {
     const cwd = path.join(import.meta.dirname, "check/deployed-missing-error");
     const result = await cli(["check"], { cwd });
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toMatch(/Deployed file not found/);
-    expect(result.stderr).toMatch(/skipIfMissing/);
+    expect(result.stderr).toMatch(/empty actor/);
   });
 
   test("--fix runs stable check after fixing", async () => {

--- a/cli/types.ts
+++ b/cli/types.ts
@@ -49,6 +49,7 @@ export type CanisterConfig = {
   initArg?: string;
   "check-stable"?: {
     path: string;
+    /** @deprecated Create the file with an empty actor instead. */
     skipIfMissing?: boolean;
   };
   migrations?: MigrationsConfig;

--- a/docs/docs/09-mops.toml.md
+++ b/docs/docs/09-mops.toml.md
@@ -130,13 +130,18 @@ Configure automatic stable variable compatibility checking for a canister. When 
 | Field         | Description                                                     |
 | ------------- | --------------------------------------------------------------- |
 | path          | Path to the deployed version's `.most` or `.mo` file (required). A `.most` file is preferred; when a `.mo` file is provided, stable types are generated from it (the file must compile successfully) |
-| skipIfMissing | If `true`, silently skip the stable check when the file doesn't exist (default: `false`) |
 
 Example:
 ```toml
 [canisters.backend.check-stable]
 path = ".old/src/main.most"
-skipIfMissing = true
+```
+
+For a new project with no prior deployment, commit a `.most` file with an empty actor at this path so the check passes against an empty baseline:
+
+```most
+// Version: 1.0.0
+actor { };
 ```
 
 ### `[canisters.<name>.migrations]`

--- a/docs/docs/cli/4-dev/04-mops-check.md
+++ b/docs/docs/cli/4-dev/04-mops-check.md
@@ -103,12 +103,11 @@ main = "src/main.mo"
 path = ".old/src/main.most"
 ```
 
-If the file at `path` doesn't exist, the check fails with an error. To silently skip the stable check when the file is missing (useful for initial deployments where no previous version exists), set `skipIfMissing = true`:
+If the file at `path` doesn't exist, the check fails with an error. For initial deployments with no prior version, commit a `.most` file at `path` with an empty actor so the check runs against an empty baseline:
 
-```toml
-[canisters.backend.check-stable]
-path = ".old/src/main.most"
-skipIfMissing = true
+```most
+// Version: 1.0.0
+actor { };
 ```
 
 For more details, see [`mops check-stable`](/cli/mops-check-stable).


### PR DESCRIPTION
## Why

`skipIfMissing` was added so initial deployments (no prior `.most` to compare against) wouldn't fail `mops check`. In practice it overlaps with a simpler, more honest pattern: commit a baseline `.most` file with an empty actor. That keeps the stable check on the happy path (always runs, always asserts compatibility against a real signature) instead of carrying a second mode where the check silently doesn't run.

## What changes for users

`skipIfMissing` still works — no behavior change. But when set, `mops check` / `mops check-stable` now print:

```
WARN: `skipIfMissing` in [canisters.backend.check-stable] is deprecated.
       Instead, create .old/src/backend.most with an empty actor:
         // Version: 1.0.0
         actor { };
```

The "Deployed file not found" error no longer suggests `skipIfMissing` either — it points to the empty-actor pattern.

### Migration

Replace

```toml
[canisters.backend.check-stable]
path = ".old/src/backend.most"
skipIfMissing = true
```

with

```toml
[canisters.backend.check-stable]
path = ".old/src/backend.most"
```

and commit `.old/src/backend.most`:

```most
// Version: 1.0.0
actor { };
```

## Notes

- Deprecation only — no removal date set. Natural follow-up is to drop the field in the next major bump.
- Docs (`mops.toml`, `mops check`) and the missing-file error message updated to recommend the empty-actor pattern. The mops-cli skill already shows it.

## Test plan

- [x] `npm run check` (tsc + svelte-check)
- [x] `cli/tests/check.test.ts` — 23/23 pass; new assertions cover the deprecation warning and the new error wording
- [ ] Manual smoke on a project with `skipIfMissing = true` (warning prints, exit code unchanged)

Made with [Cursor](https://cursor.com)