### PR TITLE
docs: mark `mops migrate`, `next`, and `build-limit` as experimental

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -20,11 +20,11 @@ Opinionated guide for Motoko projects. Covers project config, dependency managem
 
 ```toml
 [toolchain]
-moc = "1.5.1"
-lintoko = "0.9.0"
+moc = "1.7.0"
+lintoko = "0.10.0"
 
 [dependencies]
-core = "2.2.0"
+core = "2.5.0"
 
 [moc]
 args = ["--default-persistent-actors", "-W=M0223,M0236,M0237"]
@@ -34,9 +34,7 @@ main = "src/backend/main.mo"
 
 [canisters.backend.migrations]
 chain = "src/backend/migrations"
-next = "src/backend/next-migration"   # optional — needed for `mops migrate new/freeze`
-check-limit = 1
-build-limit = 100
+check-limit = 10   # optional — speeds up `mops check` when the chain gets long
 
 [canisters.backend.check-stable]
 path = ".old/src/backend/dist/backend.most"
@@ -85,7 +83,7 @@ Run after cloning or after manual `mops.toml` edits. Updates `mops.lock`. In CI,
 
 ```bash
 mops add core             # latest version
-mops add core@2.2.0       # specific version
+mops add core@2.5.0       # specific version
 mops add --dev test       # dev dependency
 ```
 
@@ -121,9 +119,9 @@ Produces `.wasm`, `.did`, and `.most` files in `[build].outputDir` (default `.mo
 ### `mops toolchain`
 
 ```bash
-mops toolchain use moc 1.5.1         # pin specific version
+mops toolchain use moc 1.7.0         # pin specific version
 mops toolchain use moc latest        # pin latest version (non-interactive)
-mops toolchain use lintoko 0.9.0     # pin specific version
+mops toolchain use lintoko 0.10.0    # pin specific version
 mops toolchain update moc            # update to latest (requires existing [toolchain] entry)
 mops toolchain update                # update all tools to latest
 mops toolchain bin moc               # print path to binary
@@ -131,24 +129,13 @@ mops toolchain bin moc               # print path to binary
 
 **Agent note**: `toolchain use <tool>` without a version opens an interactive picker — do not use in scripts or agents. Always pass a version or `latest`. `toolchain update` only works when the tool already has a `[toolchain]` entry.
 
-### `mops migrate`
+### Enhanced migrations
 
-Manage enhanced migration chains:
+When `[canisters.<name>.migrations]` is configured, `mops check`, `mops build`, and `mops check-stable` automatically inject `--enhanced-migration`. Do not add `--enhanced-migration` to `[canisters.<name>].args` — mops will error.
 
-```bash
-mops migrate new AddEmail         # create a new migration file in next-migration/
-mops migrate new AddEmail backend # specify canister explicitly
-mops migrate freeze               # move next-migration to the permanent chain
-mops migrate freeze backend       # specify canister explicitly
-```
+Create migration files directly in the `chain` directory.
 
-When `[canisters.<name>.migrations]` is configured, `mops check`, `mops build`, and `mops check-stable` automatically inject `--enhanced-migration`. Do not add `--enhanced-migration` to `[canisters.<name>].args` when using managed migrations — mops will error.
-
-`chain` and `next` must live in the same parent directory. Migration files can import from sibling folders via relative paths (e.g. shared types in `src/backend/types/`); mops stages the active chain into `<parent-of-chain>/.migrations-<canister>/`, preserving depth so relative imports resolve identically. The staged dir self-stamps a `.gitignore`; `mops init` also adds `.migrations-*/` to the project `.gitignore`.
-
-`moc` diagnostics may print paths under `.migrations-<canister>/` — a staging dir that mops removes when the command finishes. The real file has the same name under `chain/` or `next/`.
-
-Typical workflow: make a breaking change → `mops check` fails with a hint → `mops migrate new Name` → edit migration → `mops check` passes → `mops build` → deploy → `mops migrate freeze`.
+`check-limit` (optional) caps how many recent chain files `mops check` and `mops lint` consider — useful when the chain grows long and re-checking every old migration slows feedback down. `mops build` always uses the full chain. When the limit kicks in, mops stages the included files into `.migrations-<canister>/` next to the `chain` directory (auto-`.gitignore`d). `moc` diagnostics may then print paths there — the real file lives in the `chain` directory with the same name.
 
 ### `mops remove <package>`
 

--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -135,7 +135,7 @@ When `[canisters.<name>.migrations]` is configured, `mops check`, `mops build`, 
 
 Create migration files directly in the `chain` directory.
 
-`check-limit` (optional) caps how many recent chain files `mops check` and `mops lint` consider — useful when the chain grows long and re-checking every old migration slows feedback down. `mops build` always uses the full chain. When the limit kicks in, mops stages the included files into `.migrations-<canister>/` next to the `chain` directory (auto-`.gitignore`d). `moc` diagnostics may then print paths there — the real file lives in the `chain` directory with the same name.
+`check-limit` (optional) caps how many recent chain files `mops check` and `mops lint` consider — useful when the chain grows long and re-checking every old migration slows feedback down. `mops build` is unaffected by `check-limit`. When the limit kicks in, mops stages the included files into `.migrations-<canister>/` next to the `chain` directory (auto-`.gitignore`d). `moc` diagnostics may then print paths there — the real file lives in the `chain` directory with the same name.
 
 ### `mops remove <package>`
 

--- a/docs/docs/09-mops.toml.md
+++ b/docs/docs/09-mops.toml.md
@@ -116,8 +116,7 @@ Multi-canister example with per-canister flags:
 main = "src/backend/main.mo"
 
 [canisters.backend.migrations]
-chain = "migrations/backend/chain"
-next = "migrations/backend/next"
+chain = "src/backend/migrations"
 
 [canisters.frontend]
 main = "src/frontend/main.mo"
@@ -146,22 +145,20 @@ actor { };
 
 ### `[canisters.<name>.migrations]`
 
-Configure managed enhanced migration chains for a canister. When set, `mops check`, `mops build`, and `mops check-stable` auto-inject `--enhanced-migration` and you can use [`mops migrate`](/cli/mops-migrate) commands to manage the migration chain.
+Configure managed enhanced migration chains for a canister. When set, `mops check`, `mops build`, and `mops check-stable` auto-inject `--enhanced-migration` for the canister. Create migration files directly in the `chain` directory.
 
 | Field       | Description                                                     |
 | ----------- | --------------------------------------------------------------- |
-| chain       | Path to the directory containing frozen migration files (required) |
-| next        | Path to the directory for the next pending migration (optional). Required for `mops migrate new/freeze`. Must contain 0 or 1 `.mo` files. Must share the same parent directory as `chain` |
-| check-limit | Max number of migrations to pass to `moc` during `mops check` and `mops check-stable`, and to `lintoko` during `mops lint` (optional). Counts the full chain including any pending next migration |
-| build-limit | Max number of migrations to pass to `moc` during `mops build` (optional). Counts the full chain including any pending next migration |
+| chain       | Path to the directory containing migration files (required) |
+| check-limit | Max number of recent migrations to pass to `moc` during `mops check` and `mops check-stable`, and to `lintoko` during `mops lint` (optional). Useful when the chain grows long and re-checking every old migration slows feedback down |
+| next        | Path to the directory for a pending migration (optional, **experimental**). Required for the experimental [`mops migrate`](/cli/mops-migrate) workflow. Must contain 0 or 1 `.mo` files. Must share the same parent directory as `chain` |
+| build-limit | Max number of recent migrations to pass to `moc` during `mops build` (optional, **experimental**) |
 
 Example:
 ```toml
 [canisters.backend.migrations]
 chain = "migrations"
-next = "next-migration"
-check-limit = 1
-build-limit = 100
+check-limit = 10
 ```
 
 Migration files must be named so they sort lexicographically in the correct order. The recommended naming convention is `YYYYMMDD_HHMMSS_Name.mo` (e.g. `20250415_120000_AddEmail.mo`).
@@ -171,7 +168,7 @@ When `[migrations]` is configured, do not add `--enhanced-migration` to `[canist
 :::
 
 :::note
-When a `next` migration exists or chain trimming is active, mops stages the active chain into `<parent-of-chain>/.migrations-<canister>/` for compilation. This keeps the staged files at the same depth as the originals so relative imports (e.g. a shared `types/` folder next to `chain` and `next`) resolve identically. The staged dir self-stamps a `.gitignore`, and `mops init` adds `.migrations-*/` to the project `.gitignore`.
+When chain trimming is active (or a `next` migration is configured), mops stages the active chain into `<parent-of-chain>/.migrations-<canister>/` for compilation. This keeps the staged files at the same depth as the originals so relative imports (e.g. a shared `types/` folder next to the chain) resolve identically. The staged dir self-stamps a `.gitignore`, and `mops init` adds `.migrations-*/` to the project `.gitignore`.
 
 `moc` diagnostics may point to a staged path under `.migrations-<canister>/`, which mops removes when the command finishes.
 :::

--- a/docs/docs/cli/4-dev/03-mops-build.md
+++ b/docs/docs/cli/4-dev/03-mops-build.md
@@ -96,9 +96,7 @@ The `--output` CLI flag takes precedence over this config value.
 
 ## Enhanced Migration Support
 
-When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops build` automatically injects the `--enhanced-migration` flag. The frozen migration chain and any pending next migration are included in the compiled WASM.
-
-See [`mops migrate`](/cli/mops-migrate) for the full migration workflow and chain trimming configuration.
+When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops build` automatically injects the `--enhanced-migration` flag. The migration chain is included in the compiled WASM.
 
 ## Candid Compatibility
 

--- a/docs/docs/cli/4-dev/04-mops-check.md
+++ b/docs/docs/cli/4-dev/04-mops-check.md
@@ -114,11 +114,9 @@ For more details, see [`mops check-stable`](/cli/mops-check-stable).
 
 ## Enhanced migration support
 
-When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops check` automatically injects the `--enhanced-migration` flag. The frozen migration chain and any pending next migration are assembled into a temporary directory and passed to `moc`.
+When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops check` automatically injects the `--enhanced-migration` flag pointing at the configured `chain` directory.
 
-If a stable compatibility check fails and `[migrations]` is configured, a hint is shown suggesting to create a new migration with `mops migrate new <Name>`.
-
-See [`mops migrate`](/cli/mops-migrate) for the full migration workflow.
+If a stable compatibility check fails and `[migrations]` is configured, a hint is shown suggesting to create a new migration.
 
 ## Lint integration
 

--- a/docs/docs/cli/4-dev/04-mops-check.md
+++ b/docs/docs/cli/4-dev/04-mops-check.md
@@ -114,7 +114,7 @@ For more details, see [`mops check-stable`](/cli/mops-check-stable).
 
 ## Enhanced migration support
 
-When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops check` automatically injects the `--enhanced-migration` flag pointing at the configured `chain` directory.
+When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops check` automatically injects the `--enhanced-migration` flag for the canister.
 
 If a stable compatibility check fails and `[migrations]` is configured, a hint is shown suggesting to create a new migration.
 

--- a/docs/docs/cli/4-dev/05-mops-check-stable.md
+++ b/docs/docs/cli/4-dev/05-mops-check-stable.md
@@ -89,8 +89,6 @@ Show detailed output including the `moc` commands being run and the intermediate
 
 When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops check-stable` automatically injects the `--enhanced-migration` flag when generating stable type signatures. If the stable check fails and `[migrations]` is configured, a hint is shown suggesting to create a new migration.
 
-See [`mops migrate`](/cli/mops-migrate) for the full migration workflow.
-
 ## Passing flags to the Motoko compiler
 
 Any arguments after `--` are forwarded to `moc` when generating stable type signatures.

--- a/docs/docs/cli/4-dev/08-mops-migrate.md
+++ b/docs/docs/cli/4-dev/08-mops-migrate.md
@@ -5,6 +5,10 @@ sidebar_label: mops migrate
 
 # `mops migrate`
 
+:::warning Experimental
+`mops migrate` is **experimental** and not recommended for general use yet — its commands and configuration may change. The recommended workflow is to create migration files directly in your `chain` directory; see [`[canisters.<name>.migrations]`](/mops.toml#canistersnamemigrations).
+:::
+
 Manage enhanced migration chains.
 
 Migration files define how canister state transforms from one version to the next. They let you batch multiple incompatible stable state changes and deploy them together in a single upgrade. Each migration is a Motoko module with a `migration` function that takes the old state shape and returns the new one.
@@ -81,7 +85,7 @@ See [`mops.toml` reference](/mops.toml#canistersnamemigrations) for all fields.
 Large migration chains increase WASM size and compilation time. Use `check-limit` and `build-limit` to trim the chain:
 
 - **`check-limit`** — only the last N migrations are included during `mops check`, `mops check-stable`, and `mops lint`. Set to `1` for fastest type-checking and linting. Pass an explicit filter (`mops lint <name>`) or file path to lint a trimmed migration on demand.
-- **`build-limit`** — only the last N migrations are included during `mops build`. Set higher (e.g. `100`) so the deployed WASM can apply multiple pending migrations.
+- **`build-limit`** (**experimental**) — only the last N migrations are included during `mops build`. Set higher (e.g. `100`) so the deployed WASM can apply multiple pending migrations.
 
 The limits count the full virtual chain (frozen + pending next migration). This means `mops build` produces identical results whether a migration is still pending or already frozen.
 


### PR DESCRIPTION
## What changes

The recommended migrations workflow in docs and the agent skill is now:

```toml
[canisters.backend.migrations]
chain = "src/backend/migrations"
check-limit = 10   # optional — speeds up `mops check` when the chain gets long
```

Create migration files directly in the `chain` directory.

`mops migrate`, the `next` directory, and `build-limit` are still documented but clearly marked as **experimental** — they may change and aren't recommended for general use yet.

## Why

These features were being promoted as the default workflow but have limited adoption and rough edges. The plain `chain`-only setup covers the common case cleanly. Marking the rest as experimental sets expectations and gives us room to iterate.

## What users will see

- **`mops.toml` reference** (`[canisters.<name>.migrations]`): example simplified to `chain` + `check-limit`; `next` and `build-limit` rows in the field table now flagged `**experimental**`.
- **`mops migrate` page**: prominent `:::warning Experimental` admonition at the top, pointing at the recommended workflow; `build-limit` marked experimental in the chain-trimming section.
- **`mops build` / `mops check` / `mops check-stable` pages**: dropped `See [mops migrate]` cross-links from each "Enhanced migration support" section. The pages no longer push users toward the experimental command.
- **Agent skill** (`.agents/skills/mops-cli/SKILL.md`): same simplified migrations recommendation. Also bumps the example versions (moc 1.5.1 → 1.7.0, lintoko 0.9.0 → 0.10.0, core 2.2.0 → 2.5.0) to current latest.

## Follow-up worth flagging

The CLI itself still emits `mops migrate new <Name>` hints from `cli/helpers/migrations.ts` and `cli/commands/check-stable.ts`. If `mops migrate` is truly experimental, those hints should probably point at "create a migration file in the `chain` directory" instead. Separate, small PR.

## Test plan

- [x] `npm run check` passes (TypeScript + svelte-check), pre-commit hook clean
- [ ] Visual review of rendered docs (admonitions, tables) on the docs site

Made with [Cursor](https://cursor.com)