### PR TITLE
frontend: drop @dfinity/* deps in favor of @icp-sdk/core

### DIFF
--- a/frontend/declarations/bench/bench.did.d.ts
+++ b/frontend/declarations/bench/bench.did.d.ts
@@ -1,6 +1,6 @@
-import type { Principal } from '@dfinity/principal';
-import type { ActorMethod } from '@dfinity/agent';
-import type { IDL } from '@dfinity/candid';
+import type { Principal } from '@icp-sdk/core/principal';
+import type { ActorMethod } from '@icp-sdk/core/agent';
+import type { IDL } from '@icp-sdk/core/candid';
 
 export interface BenchResult {
   'rts_stable_memory_size' : bigint,

--- a/frontend/declarations/bench/index.d.ts
+++ b/frontend/declarations/bench/index.d.ts
@@ -3,9 +3,9 @@ import type {
   HttpAgentOptions,
   ActorConfig,
   Agent,
-} from "@dfinity/agent";
-import type { Principal } from "@dfinity/principal";
-import type { IDL } from "@dfinity/candid";
+} from "@icp-sdk/core/agent";
+import type { Principal } from "@icp-sdk/core/principal";
+import type { IDL } from "@icp-sdk/core/candid";
 
 import { _SERVICE } from './bench.did';
 

--- a/frontend/declarations/bench/index.js
+++ b/frontend/declarations/bench/index.js
@@ -1,4 +1,4 @@
-import { Actor, HttpAgent } from "@dfinity/agent";
+import { Actor, HttpAgent } from "@icp-sdk/core/agent";
 
 // Imports and re-exports candid interface
 import { idlFactory } from "./bench.did.js";

--- a/frontend/declarations/main/index.d.ts
+++ b/frontend/declarations/main/index.d.ts
@@ -3,9 +3,9 @@ import type {
   HttpAgentOptions,
   ActorConfig,
   Agent,
-} from "@dfinity/agent";
-import type { Principal } from "@dfinity/principal";
-import type { IDL } from "@dfinity/candid";
+} from "@icp-sdk/core/agent";
+import type { Principal } from "@icp-sdk/core/principal";
+import type { IDL } from "@icp-sdk/core/candid";
 
 import { _SERVICE } from './main.did';
 

--- a/frontend/declarations/main/index.js
+++ b/frontend/declarations/main/index.js
@@ -1,4 +1,4 @@
-import { Actor, HttpAgent } from "@dfinity/agent";
+import { Actor, HttpAgent } from "@icp-sdk/core/agent";
 
 // Imports and re-exports candid interface
 import { idlFactory } from "./main.did.js";

--- a/frontend/declarations/main/main.did.d.ts
+++ b/frontend/declarations/main/main.did.d.ts
@@ -1,6 +1,6 @@
-import type { Principal } from '@dfinity/principal';
-import type { ActorMethod } from '@dfinity/agent';
-import type { IDL } from '@dfinity/candid';
+import type { Principal } from '@icp-sdk/core/principal';
+import type { ActorMethod } from '@icp-sdk/core/agent';
+import type { IDL } from '@icp-sdk/core/candid';
 
 export interface Benchmark {
   'gc' : string,

--- a/frontend/declarations/storage/index.d.ts
+++ b/frontend/declarations/storage/index.d.ts
@@ -3,9 +3,9 @@ import type {
   HttpAgentOptions,
   ActorConfig,
   Agent,
-} from "@dfinity/agent";
-import type { Principal } from "@dfinity/principal";
-import type { IDL } from "@dfinity/candid";
+} from "@icp-sdk/core/agent";
+import type { Principal } from "@icp-sdk/core/principal";
+import type { IDL } from "@icp-sdk/core/candid";
 
 import { _SERVICE } from './storage.did';
 

--- a/frontend/declarations/storage/index.js
+++ b/frontend/declarations/storage/index.js
@@ -1,4 +1,4 @@
-import { Actor, HttpAgent } from "@dfinity/agent";
+import { Actor, HttpAgent } from "@icp-sdk/core/agent";
 
 // Imports and re-exports candid interface
 import { idlFactory } from './storage.did.js';
@@ -6,9 +6,9 @@ export { idlFactory } from './storage.did.js';
 
 /**
  *
- * @param {string | import("@dfinity/principal").Principal} canisterId Canister ID of Agent
- * @param {{agentOptions?: import("@dfinity/agent").HttpAgentOptions; actorOptions?: import("@dfinity/agent").ActorConfig}} [options]
- * @return {import("@dfinity/agent").ActorSubclass<import("./storage.did.js")._SERVICE>}
+ * @param {string | import("@icp-sdk/core/principal").Principal} canisterId Canister ID of Agent
+ * @param {{agentOptions?: import("@icp-sdk/core/agent").HttpAgentOptions; actorOptions?: import("@icp-sdk/core/agent").ActorConfig}} [options]
+ * @return {import("@icp-sdk/core/agent").ActorSubclass<import("./storage.did.js")._SERVICE>}
  */
  export const createActor = (canisterId, options) => {
   const agent = new HttpAgent({ ...options?.agentOptions });

--- a/frontend/declarations/storage/storage.did.d.ts
+++ b/frontend/declarations/storage/storage.did.d.ts
@@ -1,6 +1,6 @@
-import type { Principal } from '@dfinity/principal';
-import type { ActorMethod } from '@dfinity/agent';
-import type { IDL } from '@dfinity/candid';
+import type { Principal } from '@icp-sdk/core/principal';
+import type { ActorMethod } from '@icp-sdk/core/agent';
+import type { IDL } from '@icp-sdk/core/candid';
 
 export type Chunk = Array<number>;
 export type Err = string;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,16 +29,6 @@
 </script>
 <!-- End Matomo Code -->
 
-<script type="module">
-  /**
-   * @dfinity/agent requires this. Can be removed once it's fixed
-   */
-  import { Buffer } from "buffer";
-
-  window.global = window;
-  window.Buffer = Buffer;
-</script>
-
 <div id="root"></div>
 
 <script src="./index.ts" type="module"></script>

--- a/frontend/logic/actors.ts
+++ b/frontend/logic/actors.ts
@@ -1,4 +1,4 @@
-import { Principal } from "@dfinity/principal";
+import { Principal } from "@icp-sdk/core/principal";
 import {
   createActor as createMainActor,
   canisterId as mainCanisterId,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,8 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/core": "3.0.4",
-        "@dfinity/agent": "1.0.1",
-        "@dfinity/principal": "1.0.1",
+        "@icp-sdk/core": "4.0.2",
         "@wooorm/starry-night": "3.2.0",
         "chart.js": "4.4.2",
         "chartjs-adapter-date-fns": "^3.0.0",
@@ -32,11 +31,10 @@
         "@types/node": "22.15.3",
         "@types/pako": "2.0.4",
         "@types/throttle-debounce": "5.0.2",
-        "buffer": "^6.0.3",
         "eslint-plugin-svelte": "2.46.1",
         "svelte": "5.55.7",
         "svelte-check": "4.4.6",
-        "typescript": "5.4.3",
+        "typescript": "5.9.2",
         "vite": "8.0.8",
         "vite-plugin-static-copy": "4.0.1"
       }
@@ -255,33 +253,31 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-1.0.1.tgz",
-      "integrity": "sha512-QoCiKIWEgsXoaiHpb76M2qLXYDS9IdfvC81dLJYvX9KVXRq8Ojo4S82tBqBFGtM0j0EKEC6mIAJV/bqhOJTtjQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.4.3.tgz",
+      "integrity": "sha512-qOJqvZdMzncbbYX3eUjlAqvP66DQuOQgBFQE06yzI3m/lVXnefxvY7wE9Y1Sb2wjVIQs6W2rfjixnn4EEjHAZg==",
       "deprecated": "This package has been deprecated. Use @icp-sdk/core/agent instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@noble/curves": "^1.2.0",
-        "@noble/hashes": "^1.3.1",
-        "base64-arraybuffer": "^0.2.0",
-        "borc": "^2.1.1",
-        "buffer": "^6.0.3",
-        "simple-cbor": "^0.4.1"
+        "@dfinity/cbor": "^0.2.2",
+        "@noble/curves": "^1.9.2"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^1.0.1",
-        "@dfinity/principal": "^1.0.1"
+        "@dfinity/candid": "3.4.3",
+        "@dfinity/principal": "3.4.3",
+        "@noble/hashes": "^1.8.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-1.0.1.tgz",
-      "integrity": "sha512-PfZNV1fTOWtl+NhLOw71ACLYGugKF9HdEJKtkyBJqbj+6pqshvK6rllCUkGwMsmXfP8YopLzmoNVdy1rp/eOgg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.4.3.tgz",
+      "integrity": "sha512-M2MuNariyCZHvxT0IXvMWmg8jvG19EORDveoFm7PCIVXLgYfWSy0P59t6tQ24D72yRGu40CRLm85aqpt3cRvxw==",
       "deprecated": "This package has been deprecated. Use @icp-sdk/core/candid instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^1.0.1"
+        "@dfinity/principal": "3.4.3"
       }
     },
     "node_modules/@dfinity/cbor": {
@@ -291,14 +287,49 @@
       "license": "Apache-2.0",
       "peer": true
     },
+    "node_modules/@dfinity/identity": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.4.3.tgz",
+      "integrity": "sha512-mAsdmlaZPe7UkPL8AKNq7801pYve3LWnXQLOq39Nu+pzAUWRnZcKO3Ao+xouym5VnQnBwO68BnSSvQ044bEyTA==",
+      "deprecated": "This package has been deprecated. Use @icp-sdk/core/identity instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@dfinity/agent": "3.4.3",
+        "@dfinity/candid": "3.4.3",
+        "@dfinity/principal": "3.4.3",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0"
+      }
+    },
+    "node_modules/@dfinity/identity-secp256k1": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-3.4.3.tgz",
+      "integrity": "sha512-Mao+EQZUWJ9oG90eS3GwI3zU4zdccvhuBANBpCJWhcad84HYkr7NIJRQRYWSDmIXdALcU8jCeUvyhLxxgk0akQ==",
+      "deprecated": "This package has been deprecated. Use @icp-sdk/core/identity/secp256k1 instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@dfinity/agent": "3.4.3",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "asn1js": "^3.0.5"
+      },
+      "peerDependencies": {
+        "@dfinity/candid": "3.4.3",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0"
+      }
+    },
     "node_modules/@dfinity/principal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.0.1.tgz",
-      "integrity": "sha512-pCAuTLcvZEZ8fYgVzTVhfUfFGadxeWN4v2z8Q0rizeiqcHKhbJVfWUiXXjzPGG5lNz2DxKyUHQ/WS4UTbTaxvg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.4.3.tgz",
+      "integrity": "sha512-KTWIRqj/0clwsxcXnjgMVpnvxis6ji8vddRbBnYLsPjRFaVXHeBwVN1rziA1w3u7AtlP3kuovB4czd2F5ORxDw==",
       "deprecated": "This package has been deprecated. Use @icp-sdk/core/principal instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@noble/hashes": "^1.3.1"
+        "@noble/hashes": "^1.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -562,6 +593,19 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
+    },
+    "node_modules/@icp-sdk/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@icp-sdk/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-tiNXiLbzc4+CJV2R/sk8Iw9WREZ32SmwPPvt5qYUaQDs6A8iftr03alCkVa+Frx4CKqbeVrJehsp07Ms7ZaHWA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@dfinity/agent": "^3.2.4",
+        "@dfinity/candid": "^3.2.4",
+        "@dfinity/identity": "^3.2.4",
+        "@dfinity/identity-secp256k1": "^3.2.4",
+        "@dfinity/principal": "^3.2.4"
+      }
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
@@ -953,6 +997,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -2237,14 +2282,14 @@
       }
     },
     "node_modules/asn1js": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
         "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
+        "pvutils": "^1.1.5",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -2386,14 +2431,6 @@
         "bare-path": "^3.0.0"
       }
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2427,15 +2464,6 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -2503,48 +2531,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/borc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/borc/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bottleneck": {
@@ -3420,12 +3406,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
@@ -4576,92 +4556,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/ic-mops/node_modules/@dfinity/agent": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.4.3.tgz",
-      "integrity": "sha512-qOJqvZdMzncbbYX3eUjlAqvP66DQuOQgBFQE06yzI3m/lVXnefxvY7wE9Y1Sb2wjVIQs6W2rfjixnn4EEjHAZg==",
-      "deprecated": "This package has been deprecated. Use @icp-sdk/core/agent instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@dfinity/cbor": "^0.2.2",
-        "@noble/curves": "^1.9.2"
-      },
-      "peerDependencies": {
-        "@dfinity/candid": "3.4.3",
-        "@dfinity/principal": "3.4.3",
-        "@noble/hashes": "^1.8.0"
-      }
-    },
-    "node_modules/ic-mops/node_modules/@dfinity/candid": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.4.3.tgz",
-      "integrity": "sha512-M2MuNariyCZHvxT0IXvMWmg8jvG19EORDveoFm7PCIVXLgYfWSy0P59t6tQ24D72yRGu40CRLm85aqpt3cRvxw==",
-      "deprecated": "This package has been deprecated. Use @icp-sdk/core/candid instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "@dfinity/principal": "3.4.3"
-      }
-    },
-    "node_modules/ic-mops/node_modules/@dfinity/identity": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.4.3.tgz",
-      "integrity": "sha512-mAsdmlaZPe7UkPL8AKNq7801pYve3LWnXQLOq39Nu+pzAUWRnZcKO3Ao+xouym5VnQnBwO68BnSSvQ044bEyTA==",
-      "deprecated": "This package has been deprecated. Use @icp-sdk/core/identity instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "@dfinity/agent": "3.4.3",
-        "@dfinity/candid": "3.4.3",
-        "@dfinity/principal": "3.4.3",
-        "@noble/curves": "^1.9.2",
-        "@noble/hashes": "^1.8.0"
-      }
-    },
-    "node_modules/ic-mops/node_modules/@dfinity/identity-secp256k1": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-3.4.3.tgz",
-      "integrity": "sha512-Mao+EQZUWJ9oG90eS3GwI3zU4zdccvhuBANBpCJWhcad84HYkr7NIJRQRYWSDmIXdALcU8jCeUvyhLxxgk0akQ==",
-      "deprecated": "This package has been deprecated. Use @icp-sdk/core/identity/secp256k1 instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@dfinity/agent": "3.4.3",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "asn1js": "^3.0.5"
-      },
-      "peerDependencies": {
-        "@dfinity/candid": "3.4.3",
-        "@noble/curves": "^1.9.2",
-        "@noble/hashes": "^1.8.0"
-      }
-    },
-    "node_modules/ic-mops/node_modules/@dfinity/principal": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.4.3.tgz",
-      "integrity": "sha512-KTWIRqj/0clwsxcXnjgMVpnvxis6ji8vddRbBnYLsPjRFaVXHeBwVN1rziA1w3u7AtlP3kuovB4czd2F5ORxDw==",
-      "deprecated": "This package has been deprecated. Use @icp-sdk/core/principal instead. Migration guide: https://js.icp.build/core/latest/upgrading/v5",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@noble/hashes": "^1.8.0"
-      }
-    },
-    "node_modules/ic-mops/node_modules/@icp-sdk/core": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@icp-sdk/core/-/core-4.0.2.tgz",
-      "integrity": "sha512-tiNXiLbzc4+CJV2R/sk8Iw9WREZ32SmwPPvt5qYUaQDs6A8iftr03alCkVa+Frx4CKqbeVrJehsp07Ms7ZaHWA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@dfinity/agent": "^3.2.4",
-        "@dfinity/candid": "^3.2.4",
-        "@dfinity/identity": "^3.2.4",
-        "@dfinity/identity-secp256k1": "^3.2.4",
-        "@dfinity/principal": "^3.2.4"
-      }
-    },
     "node_modules/ic-mops/node_modules/brace-expansion": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
@@ -5079,15 +4973,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
-    "node_modules/iso-url": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/js-untar": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/js-untar/-/js-untar-2.0.0.tgz",
@@ -5169,15 +5054,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
-      "license": "MIT",
-      "dependencies": {
-        "delimit-stream": "0.1.0"
-      }
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -7075,20 +6951,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7345,12 +7207,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-cbor": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
-      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
-      "license": "ISC"
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7448,15 +7304,6 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -8015,9 +7862,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,14 +9,13 @@
     "vite": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --threshold error --no-tsconfig"
+    "check": "svelte-check --threshold error"
   },
   "author": "Zen Voich <zen.voich@gmail.com>",
   "license": "ISC",
   "dependencies": {
     "@asciidoctor/core": "3.0.4",
-    "@dfinity/agent": "1.0.1",
-    "@dfinity/principal": "1.0.1",
+    "@icp-sdk/core": "4.0.2",
     "@wooorm/starry-night": "3.2.0",
     "chart.js": "4.4.2",
     "chartjs-adapter-date-fns": "^3.0.0",
@@ -31,22 +30,16 @@
     "svelte-spa-history-router": "2.1.1",
     "throttle-debounce": "5.0.2"
   },
-  "overrides": {
-    "@dfinity/agent@1.0.1": {
-      "@dfinity/candid": "1.0.1"
-    }
-  },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "7.0.0",
     "@types/throttle-debounce": "5.0.2",
     "@types/markdown-it": "13.0.7",
     "@types/node": "22.15.3",
     "@types/pako": "2.0.4",
-    "buffer": "^6.0.3",
     "eslint-plugin-svelte": "2.46.1",
     "svelte": "5.55.7",
     "svelte-check": "4.4.6",
-    "typescript": "5.4.3",
+    "typescript": "5.9.2",
     "vite": "8.0.8",
     "vite-plugin-static-copy": "4.0.1"
   }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,7 +20,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "types": ["node", "vite/client"],
     "baseUrl": ".",
     "outDir": "dist",

--- a/frontend/types.d.ts
+++ b/frontend/types.d.ts
@@ -1,7 +1,12 @@
 declare global {
+	// Write side: components/package/Package.svelte sets this on `window`.
 	interface Window {
 		MOPS_NETWORK : string;
 	}
+	// Read side: ic-mops/api/network.ts reads it via `globalThis`.
+	// Both declarations are needed — keep them in sync.
+	// eslint-disable-next-line no-var
+	var MOPS_NETWORK: string;
 }
 
 export {};


### PR DESCRIPTION
The frontend was the last spot in the repo still importing the deprecated `@dfinity/{agent,principal,candid}@1.0.1` packages. Switching to `@icp-sdk/core@4.0.2` aligns it with the CLI, which already migrated.

Phase 1 of [LANG-1311](https://linear.app/caffeinelabs/issue/LANG-1311). Repo-internal only — no API or runtime behavior change.

## Side effects worth flagging in review

- **`tsconfig.json`: `moduleResolution: node` → `bundler`.** `@icp-sdk/core` ships its API behind the `exports` field, which legacy `node` resolution can't follow. `bundler` matches the CLI.
- **TypeScript 5.4.3 → 5.9.2 to match the CLI's pin.** 5.7 is the actual minimum (`Uint8Array<ArrayBufferLike>` in the underlying `@dfinity/agent@3.x` types resolves to `any` on older TS, cascading into "implicit any" errors on Svelte components), but matching the CLI avoids carrying two TS versions.
- **`svelte-check` no longer runs with `--no-tsconfig`.** That flag was bypassing `skipLibCheck` and letting the cascade above slip through. Using the project's `tsconfig` matches what the IDE shows. One node_modules-side issue fell out of this — `ic-mops@2.5.0` reads `globalThis.MOPS_NETWORK` from `api/network.ts` but only declares it in the CLI bundle, so the global is added to `frontend/types.d.ts`.
- **`Buffer` polyfill removed** from `index.html` (only needed by `@dfinity/agent@1.0.1`), along with the `buffer` devDep.

## What this does *not* do

- Does **not** remove deprecation warnings on `npm i ic-mops` for end users — those come from the CLI's deps, not the frontend.
- Does **not** fully clean up `@dfinity/*` from the install tree. `@icp-sdk/core@4.0.2` still pulls them as peer deps; this PR only stops the frontend from depending on them directly. A follow-up bump to `@icp-sdk/core@5.x` (which is self-contained) would finish the job, but that's separate and breaking.
- Does **not** rename `DFX_NETWORK` env-var references — that's Phase 2 of LANG-1311.

## Test plan

- [x] `npm run --prefix frontend check` — 0 errors, 21 warnings (same warnings as `main`)
- [x] `npm run --prefix frontend build` — succeeds
- [ ] **Smoke-test on staging before merge** — Buffer-polyfill removal + actor SDK swap is the kind of change that compiles clean but trips at runtime. Exercise the package-install path that reads `globalThis.MOPS_NETWORK` via `ic-mops/api/downloadPackageFiles`.