### PR TITLE
chore(cli): deprecate vessel.dhall auto-migration in `mops init`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -45,7 +45,6 @@ Refs: GH = `caffeinelabs/mops`, LIN = Linear ticket title.
 
 - `MOPS_*` env-var overrides (`MOPS_NETWORK`, `MOPS_REGISTRY_HOST`, `MOPS_REGISTRY_CANISTER_ID`, `MOPS_VERIFY_QUERY_SIGNATURES`, `MOPS_CWD`, `MOPS_ENV`): document, log when active, add proper flag equivalents. Today they silently change registry/network/cwd. (`cli/api/network.ts`, `cli/api/actors.ts`, `cli/cli.ts:72`)
 - `GITHUB_ENV`-triggered concurrency change (`cli/commands/install/install-mops-dep.ts:85`) — replace with explicit `--concurrency` flag.
-- Vessel / dhall: emit one-time warning on `mops init` when `vessel.dhall` is present (`cli/commands/init.ts:39-55`); remove in v3. (GH #296)
 - `dfx`-bundled moc fallback: warn on every fallback today (`cli/commands/toolchain/index.ts:359,387`, `cli/commands/docs.ts:44-54`); drop in v3.
 - WASI `wasmtime` PATH fallback already labelled "legacy" — already warns (`cli/commands/test/test.ts:270-280`); remove in v3.
 - `// compatibility with older versions` re-exports (`cli/mops.ts:324-325`): mark `@deprecated`, document successors.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
-- Deprecate the `vessel.dhall` auto-migration in `mops init`. Behavior is unchanged for now — `vessel.dhall` is still read and its dependencies copied into `mops.toml` — but a warning is printed, and the migration will be removed in mops v3. Copy dependencies into `mops.toml` manually and delete `vessel.dhall` / `package-set.dhall`.
+- Deprecate the `vessel.dhall` auto-migration in `mops init`. Behavior is unchanged for now — interactive `mops init` still reads `vessel.dhall` and copies its dependencies into `mops.toml` — but a warning is printed (also under `--yes`, which still skips the migration itself), and the migration will be removed in mops v3. Before then, copy your dependencies into `mops.toml` manually and delete `vessel.dhall` / `package-set.dhall`.
 
 - Fix `mops install` race conditions when multiple processes install into the same project (e.g. an editor watcher, fixture installers like vscode-motoko's, or CI matrix jobs sharing a global cache). Concurrent runs could observe a half-populated global cache or local `.mops/<pkg>` directory and copy zero-byte / truncated files, surfacing later as missing completions, hover data, or type-check errors. Cache writes (mops registry, GitHub installs, and project-local `.mops/`) now stage into a sibling `.staging-*` dir and atomically rename onto the canonical path. Stale staging dirs from interrupted runs are swept on the next install. The shared `.mops/_tmp/` zip download dir used by GitHub installs is also per-invocation now. If you have zero-byte files left over in your cache from a pre-fix crash, run `mops cache clean` once after upgrading.
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Mops CLI Changelog
 
 ## Next
+- Deprecate the `vessel.dhall` auto-migration in `mops init`. Behavior is unchanged for now — `vessel.dhall` is still read and its dependencies copied into `mops.toml` — but a warning is printed, and the migration will be removed in mops v3. Copy dependencies into `mops.toml` manually and delete `vessel.dhall` / `package-set.dhall`.
+
 - Fix `mops install` race conditions when multiple processes install into the same project (e.g. an editor watcher, fixture installers like vscode-motoko's, or CI matrix jobs sharing a global cache). Concurrent runs could observe a half-populated global cache or local `.mops/<pkg>` directory and copy zero-byte / truncated files, surfacing later as missing completions, hover data, or type-check errors. Cache writes (mops registry, GitHub installs, and project-local `.mops/`) now stage into a sibling `.staging-*` dir and atomically rename onto the canonical path. Stale staging dirs from interrupted runs are swept on the next install. The shared `.mops/_tmp/` zip download dir used by GitHub installs is also per-invocation now. If you have zero-byte files left over in your cache from a pre-fix crash, run `mops cache clean` once after upgrading.
 
 - Replace `@iarna/toml` with `smol-toml` for parsing and writing `mops.toml` (faster, actively maintained, spec-compliant TOML parser). Config reformat behavior on `add`/`remove`/`bump`/`toolchain` is unchanged — both libraries round-trip through a plain object.

--- a/cli/commands/init.ts
+++ b/cli/commands/init.ts
@@ -41,6 +41,12 @@ export async function init({ yes = false } = {}) {
   let vesselConfig: VesselConfig = { dependencies: [], "dev-dependencies": [] };
 
   if (existsSync(vesselFile)) {
+    console.warn(
+      chalk.yellow(
+        "WARN: vessel.dhall auto-migration is deprecated and will be removed in mops v3. " +
+          "Copy your dependencies into mops.toml manually and delete vessel.dhall / package-set.dhall.",
+      ),
+    );
     console.log("Reading vessel.dhall file");
     let res = await readVesselConfig(process.cwd(), { cache: false });
     if (res) {

--- a/cli/commands/init.ts
+++ b/cli/commands/init.ts
@@ -25,6 +25,20 @@ export async function init({ yes = false } = {}) {
 
   let config: Config = {};
 
+  let vesselFile = path.join(process.cwd(), "vessel.dhall");
+  let vesselExists = existsSync(vesselFile);
+
+  // Warn before the --yes early-return so scripted/CI users get the heads-up
+  // even though `mops init --yes` skips the vessel migration entirely.
+  if (vesselExists) {
+    console.warn(
+      chalk.yellow(
+        "WARN: vessel.dhall auto-migration is deprecated and will be removed in mops v3. " +
+          "Before then, copy your dependencies into mops.toml manually and delete vessel.dhall / package-set.dhall.",
+      ),
+    );
+  }
+
   if (yes) {
     await applyInit({
       type: "project",
@@ -37,16 +51,9 @@ export async function init({ yes = false } = {}) {
   }
 
   // migrate from vessel
-  let vesselFile = path.join(process.cwd(), "vessel.dhall");
   let vesselConfig: VesselConfig = { dependencies: [], "dev-dependencies": [] };
 
-  if (existsSync(vesselFile)) {
-    console.warn(
-      chalk.yellow(
-        "WARN: vessel.dhall auto-migration is deprecated and will be removed in mops v3. " +
-          "Copy your dependencies into mops.toml manually and delete vessel.dhall / package-set.dhall.",
-      ),
-    );
+  if (vesselExists) {
     console.log("Reading vessel.dhall file");
     let res = await readVesselConfig(process.cwd(), { cache: false });
     if (res) {

--- a/docs/docs/cli/00-mops-init.md
+++ b/docs/docs/cli/00-mops-init.md
@@ -63,7 +63,9 @@ For projects, `mops install` runs at the end to fetch the default packages.
 
 ### Migrating from Vessel
 
-If `vessel.dhall` exists, `mops init` reads it and copies the listed dependencies into the new `mops.toml`. Dev-dependencies are not migrated. Skipped when `--yes` is used.
+> **Deprecated.** Auto-migration is scheduled for removal in mops v3. Copy your dependencies into `mops.toml` manually and delete `vessel.dhall` / `package-set.dhall`.
+
+If `vessel.dhall` exists, `mops init` reads it and copies the listed dependencies into the new `mops.toml`. Dev-dependencies are not migrated. Skipped when `--yes` is used. A deprecation warning is printed.
 
 ## Options
 

--- a/docs/docs/cli/00-mops-init.md
+++ b/docs/docs/cli/00-mops-init.md
@@ -65,7 +65,7 @@ For projects, `mops install` runs at the end to fetch the default packages.
 
 > **Deprecated.** Auto-migration is scheduled for removal in mops v3. Copy your dependencies into `mops.toml` manually and delete `vessel.dhall` / `package-set.dhall`.
 
-If `vessel.dhall` exists, `mops init` reads it and copies the listed dependencies into the new `mops.toml`. Dev-dependencies are not migrated. Skipped when `--yes` is used. A deprecation warning is printed.
+If `vessel.dhall` exists, `mops init` reads it and copies the listed dependencies into the new `mops.toml`. Dev-dependencies are not migrated. Skipped when `--yes` is used. A deprecation warning is printed whenever `vessel.dhall` is detected — including under `--yes`, where the migration itself is also skipped.
 
 ## Options
 

--- a/frontend/components/docs/InstallDoc.svelte
+++ b/frontend/components/docs/InstallDoc.svelte
@@ -39,7 +39,6 @@
 
 		<h3>3. Initialize</h3>
 		<div>Run this command in the root directory of your project (where is <code class="inline">dfx.json</code> placed)</div>
-		<div>If there are Vessel config files, mops will migrate packages from <code class="inline">vessel.dhall</code> to <code class="inline">mops.toml</code></div>
 		<br>
 		<code>mops init</code>
 


### PR DESCRIPTION
## What changes for users

Users with `vessel.dhall` in their project will see a deprecation warning when running `mops init`:

```
WARN: vessel.dhall auto-migration is deprecated and will be removed in mops v3.
Before then, copy your dependencies into mops.toml manually and delete vessel.dhall / package-set.dhall.
```

Migration behavior is unchanged:
- **Interactive `mops init`**: still reads `vessel.dhall` and copies its dependencies into `mops.toml`, then prints the warning.
- **`mops init --yes`**: still skips the migration (long-standing behavior), but now also prints the warning when `vessel.dhall` is present — so scripted / CI users get the heads-up too.

Nothing breaks today.

## Why

Vessel is the legacy Motoko package manager; mops has replaced it. The auto-migration helper has lived in `mops init` for years but the maintenance cost (a `dhall-to-json-cli` dependency, the `cli/vessel.ts` reader, vessel-shaped configs in the resolver) keeps growing while the user base shrinks. Removal is tracked in `NEXT-MAJOR.md` for v3 (GH #296); this PR is the 2.x heads-up promised in `TODO.md`.

## Notes

Mirrors the existing `skipIfMissing` deprecation pattern in `cli/commands/check-stable.ts` (same chalk-yellow WARN shape, same "removed in v3" framing). That pattern has a one-liner test in `cli/tests/check.test.ts:116`; adding the equivalent here would require setting up the first `mops init` test harness in the repo (interactive prompts + network for `getDefaultPackages`), which is out of scope.