### PR TITLE
Add icp.yaml mirroring dfx.json (LANG-1311 Phase 2a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 target/
 dist/
 .dfx/
+.icp/cache/
 .mops/
 .migrations-*/
 mops.lock

--- a/cli/specs/dfx-to-icp.md
+++ b/cli/specs/dfx-to-icp.md
@@ -237,7 +237,7 @@ used or when only `dfx.json` is present. Removal target: next major.
   `@icp-sdk/bindgen`, with output-shape caveat.
 - ~~`getDefaultPackages("")` behavior?~~ Falls through to latest `core`.
 - ~~`icp.yaml` schema works for our canisters?~~ Yes — `icp project show`
-  parses the file with all six canisters (Phase 2a).
+  parses the file with all seven canisters (Phase 2a).
 
 ## References
 

--- a/cli/specs/dfx-to-icp.md
+++ b/cli/specs/dfx-to-icp.md
@@ -119,16 +119,46 @@ Phase 2 splits into three follow-on PRs, ordered by risk.
 
 ### Phase 2a — foundation (this PR)
 
-1. Add `icp.yaml` mirroring `dfx.json`. Six canisters: `main`, `bench`
-   (Motoko recipe), `assets`, `docs`, `blog`, `cli` (asset-canister recipe).
+1. Add `icp.yaml` describing seven canisters:
+   - `main`, `bench` — `@dfinity/motoko@v4.1.0` recipe.
+   - `assets`, `docs`, `blog` — `@dfinity/asset-canister@v2.1.0` recipe.
+   - `cli` — raw `build`/`sync` (the recipe takes a single `dir`, but
+     `dfx.json` ships two sources: `cli-releases/` for `install.sh` /
+     `releases.json` / `tags/` / `versions/` and `cli-releases/frontend/dist/`
+     for the SPA).
+   - `play-frontend` — raw `build`/`sync` (no build step; just serves
+     `.well-known/ic-domains`).
+
    Local network pinned to `127.0.0.1:4943` so the existing Vite `/api` proxy
    keeps working when devs opt in to `icp network start`.
-2. `.gitignore` adds `.icp/cache/`. (Track `.icp/data/` later when we have
-   mainnet IDs to record there.)
+
+2. `.gitignore` adds `.icp/cache/`.
+
 3. `dfx.json`, npm scripts, CI workflows, and Vite are unchanged — daily dev
    stays on `dfx` until Phase 2b lands.
 
-Validation: `icp project show` parses the file and lists all six canisters.
+Validation: `icp project show` parses the file and lists all seven canisters.
+
+**Known semantic gaps vs. `dfx.json`** (carry into Phase 2b/2c):
+
+- `optimize: "cycles"` (binaryen `wasm-opt -O*` via `ic-wasm optimize`) on
+  `main` becomes `shrink: true` (function reordering / dead-code only) under
+  the recipe. The deployed wasm will be larger. Need to either accept it,
+  switch to raw `build.steps` with a manual `ic-wasm optimize` call, or wait
+  for the recipe to expose `optimize`.
+- `bench.remote.id` ("don't redeploy on `ic`/`staging`, just reuse
+  `2222s-...`") has no recipe equivalent. Pre-populate
+  `.icp/data/mappings/.ids.json` for `bench` before any non-local deploy.
+- `staging` network is not yet defined in `icp.yaml` — only the implicit
+  `ic`. Phase 2c needs to add a `staging` network entry alongside the IDs
+  mapping.
+- Local network mode flips from `ephemeral` (state wiped on `dfx start
+  --clean`) to `managed` (state persists across `icp network stop/start`).
+  Phase 2b should document the equivalent reset workflow when flipping
+  `npm run replica`.
+- `.icp/data/mappings/` is intended to be tracked (mainnet/staging IDs);
+  ephemeral managed-network state goes elsewhere under `.icp/data/<network>/`.
+  Refine `.gitignore` in Phase 2b once we have actual deploys to observe.
 
 ### Phase 2b — flip dev pipeline
 

--- a/cli/specs/dfx-to-icp.md
+++ b/cli/specs/dfx-to-icp.md
@@ -1,0 +1,224 @@
+# Spec: `dfx-to-icp` migration
+
+Status: Phase 1 merged · Phase 2a in flight
+Owner: mops CLI
+Tracking: [LANG-1311](https://linear.app/...)
+
+## Motivation
+
+`dfx` is being superseded by [`icp-cli`](https://cli.internetcomputer.org/).
+Mops integrates with `dfx` in three places:
+
+1. **Frontend SDKs** (`@dfinity/agent`, `@dfinity/principal`, …) — done in Phase 1.
+2. **Internal dev pipeline** (`dfx.json`, `dfx start/deploy/generate` in root
+   `package.json` scripts).
+3. **CLI runtime** (`getDfxVersion`, `dfx.json` parsing, `--replica dfx`).
+
+Migration order: **dogfood internally first** (Phase 2), then make the CLI
+`icp.yaml`-aware (Phase 4), then deprecate `--replica dfx` for users (Phase 3).
+The credibility argument from `NEXT-MAJOR.md` applies — we shouldn't deprecate
+what we still rely on ourselves.
+
+## Spike findings
+
+### Q1 — Does `icp-cli` have a `packtool` extension point?
+
+**No direct equivalent.** `icp.yaml` has no global `defaults.build.packtool`
+hook. Build configuration is per-canister.
+
+**Mops integration path**: the official [`@dfinity/motoko` recipe][motoko-recipe]
+embeds `$(mops sources)` directly in the `moc` invocation:
+
+```text
+$(mops toolchain bin moc) "{{ main }}" ... $(mops sources) -o "$ICP_WASM_OUTPUT_PATH"
+```
+
+So a Motoko canister using mops looks like:
+
+```yaml
+canisters:
+  - name: backend
+    recipe:
+      type: "@dfinity/motoko@v4.1.0"
+      configuration:
+        main: src/main.mo
+```
+
+Users don't pass anything themselves — the recipe handles `mops sources` and
+`mops toolchain bin moc` transparently. `mops.toml` must sit next to `icp.yaml`
+(inline canisters) or each `canister.yaml` (path-based).
+
+If a user opts out of recipes and writes raw `build.steps`, they must inline
+`$(mops sources)` themselves — there is **no shared "before every build" hook**.
+
+**Implication for our `init` command**: when scaffolding for icp-cli, we should
+either (a) recommend the recipe, or (b) emit a `build.steps` script with
+`$(mops sources)` inlined. We don't need a new packtool integration — we just
+need to know which `icp.yaml` style we're scaffolding into.
+
+### Q2 — Standalone declaration generation outside Vite
+
+**No `icp generate` subcommand.** [icp-cli docs][icp-bindgen-concept] explicitly
+delegate binding generation to [`@icp-sdk/bindgen`][bindgen-cli]. It runs
+standalone:
+
+```bash
+npm i -D @icp-sdk/bindgen
+icp-bindgen --did-file backend/main/main.did --out-dir cli/declarations/main
+```
+
+It takes a `.did` file, **not a canister name**, so we need the `.did` on disk
+first. For Motoko sources we can extract via:
+
+```bash
+$(mops toolchain bin moc) --idl $(mops sources) -o backend/main/main.did backend/main/app.mo
+```
+
+Or use `candid-extractor` against a built wasm.
+
+**Output shape differs from `dfx generate`** ([docs][bindgen-structure]):
+
+| `dfx generate <name>` | `icp-bindgen --out-dir out` |
+| --- | --- |
+| `out/index.js` | `out/<name>.ts` (combined JS + types) |
+| `out/index.d.ts` | — |
+| `out/<name>.did.js` | `out/declarations/<name>.did.js` |
+| `out/<name>.did.d.ts` | `out/declarations/<name>.did.d.ts` |
+
+`--declarations-flat` collapses `declarations/` into `--out-dir`.
+`--actor-disabled` skips the `<name>.ts` wrapper, leaving committed
+`index.{js,d.ts}` shims in place. See **Phase 2c** below for the recommended
+flow + caveats discovered while validating against our actual `main.did`.
+
+### Q3 — `getDefaultPackages("")` behavior
+
+`backend/main/registry/getDefaultPackages.mo` switches on `dfxVersion`:
+
+- Versions `0.9.0` … `0.27.0` map to a pinned `base` version.
+- **Wildcard `_`** (matches `""` and any unknown version) returns
+  `[("core", <highest version in registry>)]`, or `[]` if `core` isn't
+  published yet.
+
+Today `mops init` ([`cli/commands/init.ts:244`](cli/commands/init.ts)) reads
+`dfxVersion` from `dfx.json`, falls back to `dfx --version`, and on failure
+passes `""` — so an icp-only user already gets the right answer (latest
+`core`). **No backend or `init` change is needed for Phase 4.**
+
+When we drop the `dfx --version` probe and `dfx.json` lookup, we just keep
+passing `""` and the user automatically lands on `core`. That aligns with the
+"`base` is deprecated, use `core`" workspace rule.
+
+The function signature
+`getDefaultPackages(dfxVersion : Text) : async [(PackageName, PackageVersion)]`
+should stay — renaming or repurposing the parameter is a backend ABI change
+with no upside (callers already pass `""` when there's no dfx).
+
+## Phase 2 plan
+
+Phase 2 splits into three follow-on PRs, ordered by risk.
+
+### Phase 2a — foundation (this PR)
+
+1. Add `icp.yaml` mirroring `dfx.json`. Six canisters: `main`, `bench`
+   (Motoko recipe), `assets`, `docs`, `blog`, `cli` (asset-canister recipe).
+   Local network pinned to `127.0.0.1:4943` so the existing Vite `/api` proxy
+   keeps working when devs opt in to `icp network start`.
+2. `.gitignore` adds `.icp/cache/`. (Track `.icp/data/` later when we have
+   mainnet IDs to record there.)
+3. `dfx.json`, npm scripts, CI workflows, and Vite are unchanged — daily dev
+   stays on `dfx` until Phase 2b lands.
+
+Validation: `icp project show` parses the file and lists all six canisters.
+
+### Phase 2b — flip dev pipeline
+
+1. Root `package.json`: swap `replica`, `deploy-local`, and `decl:cli` to
+   `icp` equivalents (`icp network start`, `icp deploy -e local`, the
+   `icp-bindgen` flow described below).
+2. `frontend/vite.config.ts`: read canister IDs from
+   `.icp/cache/mappings/.ids.json` (managed/local) with a `.dfx/local/...`
+   fallback. **Validate the file format first** — confirmed by running `icp
+   deploy -e local` once on a real machine before the PR is opened.
+3. `.github/workflows/ci.yml`: install icp-cli (no published `setup-icp`
+   action yet — likely `npm i -g @icp-sdk/icp-cli` or curl install). Keep
+   `setup-dfx` until `mops watch` and the CLI test suite no longer require
+   `dfx`.
+4. `mops watch` (`cli/commands/watch/deployer.ts`,
+   `cli/commands/watch/generator.ts`) still shells out to `dfx ping/canister
+   create/generate`. Either update those to detect icp first, or document
+   that `mops watch` requires `dfx` for now.
+
+### Phase 2c — regenerate declarations
+
+`icp-bindgen` is functionally compatible with the existing `cli/declarations/`
+shape (with `--declarations-flat --actor-disabled`), but the output has
+notable cosmetic differences from `dfx generate`:
+
+- Prepends `/* eslint-disable */` + `// @ts-nocheck` + autogen banner.
+- Reorders fields inside generated records — appears non-deterministic
+  between runs, which would create merge churn.
+- Narrows blob types from `Uint8Array | number[]` to just `Uint8Array`. This
+  is a **semantic** change. `cli/integrity.ts:51-58` mirrors the wider type;
+  consumers that pass `number[]` directly would break.
+
+Recommended approach for Phase 2c: regenerate everything in one PR, accept
+the large-but-mostly-cosmetic diff in `cli/declarations/` and
+`frontend/declarations/`, and fix the few real consumer types that were
+relying on `number[]`. Re-emit `index.{js,d.ts}` from a hand-maintained
+template (since `--actor-disabled` skips bindgen's actor wrapper).
+
+`decl:cli` becomes:
+
+```bash
+"$(mops toolchain bin moc)" --idl backend/main/main-canister.mo $(mops sources) \
+  -o cli/declarations/main/main.did
+npx -p @icp-sdk/bindgen icp-bindgen \
+  --did-file cli/declarations/main/main.did \
+  --out-dir cli/declarations/main \
+  --declarations-flat --actor-disabled --force
+# index.{js,d.ts} are committed and untouched
+```
+
+The same flow runs for `bench`. Verified end-to-end against today's
+`backend/main/main-canister.mo` (output structurally matches the committed
+declarations).
+
+Production deploys (`release.yml`, `deploy-staging`, `deploy-ic`) stay on
+`dfx` until we have a separate PR that pre-populates `.icp/data/mappings/.ids.json`
+with our existing mainnet canister IDs (`2d2zu-...`, `ogp6e-...`). `icp.yaml`
+has no `specified_id` equivalent — pre-existing canisters must be recorded in
+the IDs mapping file before deploy.
+
+## Phase 4 plan
+
+`cli/mops.ts` and `cli/commands/watch/parseDfxJson.ts` need to read either
+`icp.yaml` or `dfx.json`. Introduce a `project-config.ts` helper that returns a
+unified canister list. Keep `--replica dfx` working until Phase 3 closes it.
+
+## Phase 3 plan
+
+After Phase 2 + 4 ship: emit a deprecation warning when `--replica dfx` is
+used or when only `dfx.json` is present. Removal target: next major.
+
+## Open questions resolved
+
+- ~~Does `icp-cli` have a `packtool` hook?~~ No — recipe pattern instead.
+- ~~`dfx generate` standalone replacement?~~ `icp-bindgen` from
+  `@icp-sdk/bindgen`, with output-shape caveat.
+- ~~`getDefaultPackages("")` behavior?~~ Falls through to latest `core`.
+- ~~`icp.yaml` schema works for our canisters?~~ Yes — `icp project show`
+  parses the file with all six canisters (Phase 2a).
+
+## References
+
+- [`@dfinity/motoko` recipe source][motoko-recipe]
+- [icp-cli configuration reference][icp-config]
+- [`icp-bindgen` CLI usage][bindgen-cli]
+- [`icp-bindgen` output structure][bindgen-structure]
+- [icp-cli "binding generation" concept page][icp-bindgen-concept]
+
+[motoko-recipe]: https://github.com/dfinity/icp-cli-recipes/blob/main/recipes/motoko/recipe.hbs
+[icp-config]: https://cli.internetcomputer.org/0.2/reference/configuration/
+[icp-bindgen-concept]: https://cli.internetcomputer.org/0.2/concepts/binding-generation/
+[bindgen-cli]: https://js.icp.build/bindgen/latest/cli/
+[bindgen-structure]: https://js.icp.build/bindgen/latest/structure

--- a/icp.yaml
+++ b/icp.yaml
@@ -37,13 +37,36 @@ canisters:
         dir: blog/build
         build:
           - npm run build-blog
+  # Raw build/sync (not the recipe) because the asset-canister recipe template
+  # only supports a single `dir`, but dfx.json ships two sources for `cli`:
+  # `cli-releases/` (install.sh, releases.json, tags/, versions/ — served at
+  # cli.mops.one) and `cli-releases/frontend/dist/` (the SPA).
   - name: cli
-    recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
-      configuration:
-        dir: cli-releases/frontend/dist
-        build:
-          - npm run build-cli-releases
+    build:
+      steps:
+        - type: script
+          commands:
+            - npm run build-cli-releases
+        - type: pre-built
+          url: https://github.com/dfinity/sdk/releases/download/0.29.1/assetstorage.wasm.gz
+    sync:
+      steps:
+        - type: assets
+          dirs:
+            - cli-releases
+            - cli-releases/frontend/dist
+  # Static-only canister: no build step, just serves
+  # play-frontend/.well-known/ic-domains. dfx.json keeps it for parity with
+  # the deployed canister rcr7f-viaaa-aaaam-qdx6q-cai.
+  - name: play-frontend
+    build:
+      steps:
+        - type: pre-built
+          url: https://github.com/dfinity/sdk/releases/download/0.29.1/assetstorage.wasm.gz
+    sync:
+      steps:
+        - type: assets
+          dir: play-frontend
 
 # Override the default local network to bind on dfx's port so vite's
 # /api proxy keeps working while both pipelines coexist.

--- a/icp.yaml
+++ b/icp.yaml
@@ -20,6 +20,7 @@ canisters:
     recipe:
       type: "@dfinity/asset-canister@v2.1.0"
       configuration:
+        version: "0.29.1"
         dir: frontend/dist
         build:
           - npm run build-frontend
@@ -27,6 +28,7 @@ canisters:
     recipe:
       type: "@dfinity/asset-canister@v2.1.0"
       configuration:
+        version: "0.29.1"
         dir: docs/build
         build:
           - npm run build-docs
@@ -34,6 +36,7 @@ canisters:
     recipe:
       type: "@dfinity/asset-canister@v2.1.0"
       configuration:
+        version: "0.29.1"
         dir: blog/build
         build:
           - npm run build-blog

--- a/icp.yaml
+++ b/icp.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/dfinity/icp-cli/main/docs/schemas/icp-yaml-schema.json
+#
+# Mirrors dfx.json. Currently a foundation file: developer scripts, CI, and
+# Vite still target dfx. Tracking in cli/specs/dfx-to-icp.md (LANG-1311).
+
+canisters:
+  - name: main
+    recipe:
+      type: "@dfinity/motoko@v4.1.0"
+      configuration:
+        main: backend/main/main-canister.mo
+        compress: true
+        shrink: true
+  - name: bench
+    recipe:
+      type: "@dfinity/motoko@v4.1.0"
+      configuration:
+        main: cli/commands/bench/bench-canister.mo
+  - name: assets
+    recipe:
+      type: "@dfinity/asset-canister@v2.1.0"
+      configuration:
+        dir: frontend/dist
+        build:
+          - npm run build-frontend
+  - name: docs
+    recipe:
+      type: "@dfinity/asset-canister@v2.1.0"
+      configuration:
+        dir: docs/build
+        build:
+          - npm run build-docs
+  - name: blog
+    recipe:
+      type: "@dfinity/asset-canister@v2.1.0"
+      configuration:
+        dir: blog/build
+        build:
+          - npm run build-blog
+  - name: cli
+    recipe:
+      type: "@dfinity/asset-canister@v2.1.0"
+      configuration:
+        dir: cli-releases/frontend/dist
+        build:
+          - npm run build-cli-releases
+
+# Override the default local network to bind on dfx's port so vite's
+# /api proxy keeps working while both pipelines coexist.
+networks:
+  - name: local
+    mode: managed
+    gateway:
+      bind: 127.0.0.1
+      port: 4943


### PR DESCRIPTION
First step of the dfx → icp-cli migration ([LANG-1311](https://linear.app/caffeinelabs/issue/LANG-1311), follow-up to #545).

## What this changes

- Adds `icp.yaml` describing the seven deployable canisters from `dfx.json`:
  - `main`, `bench` — `@dfinity/motoko@v4.1.0` recipe
  - `assets`, `docs`, `blog` — `@dfinity/asset-canister@v2.1.0` recipe
  - `cli` — raw `build`/`sync` with `dirs: [cli-releases, cli-releases/frontend/dist]` (the recipe takes a single `dir`, but we ship two: the install.sh payload + the SPA)
  - `play-frontend` — raw `build`/`sync` (no build step; just serves `.well-known/ic-domains`)
- Local network pinned to `127.0.0.1:4943` so Vite's `/api` proxy keeps working when devs opt in to `icp network start`.
- `.gitignore` adds `.icp/cache/`.
- `cli/specs/dfx-to-icp.md` documents the Phase 1 → 2a → 2b → 2c → 4 → 3 plan, spike findings, and **known semantic gaps vs. dfx.json** that Phase 2b/2c will need to close (optimize→shrink downgrade on main, missing `bench.remote.id` equivalent, no `staging` network yet, ephemeral→managed local mode change).

`storage` is intentionally omitted — `main` spawns it dynamically.

## What this doesn't change

`dfx.json`, npm scripts, CI workflows, and `frontend/vite.config.ts` are untouched. Daily `npm start` / `npm run replica` / `npm run deploy-local` / `npm run decl:cli` keep using dfx exactly as before — there is **no behavior change** for anyone on `main`.

This is foundation: it lets follow-up PRs (Phase 2b: flip the dev scripts; Phase 2c: regenerate declarations via `icp-bindgen` and migrate prod deploys) cite a concrete `icp.yaml` instead of inventing one in the same diff.

## Validation

```text
$ icp project show
canisters: bench / main / assets / cli / docs / play-frontend / blog   ← all seven parse
$ icp environment list
local
ic
```

Tested with `icp 0.2.5`. Recipe versions are pinned (`@dfinity/motoko@v4.1.0`, `@dfinity/asset-canister@v2.1.0`) so future recipe changes are opt-in.

## Why split out from full Phase 2

Probing `icp-bindgen` against our actual `main.did` showed a noisy diff (eslint banner, non-deterministic field ordering, `Uint8Array | number[]` narrowed to `Uint8Array`) that warrants its own focused PR. Splitting also keeps prod deploys (`release.yml`, `deploy-staging`, `deploy-ic`) on dfx until we've solved the specified-canister-ID question — `icp.yaml` has no `specified_id` equivalent, so pre-existing canisters (`2d2zu-...` for main, `ogp6e-...` for assets, `rcr7f-...` for play-frontend, etc.) need `.icp/data/mappings/.ids.json` pre-population.

Full plan in `cli/specs/dfx-to-icp.md`.