### PR TITLE
Add `mops update --patch` for patch-only bumps

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -150,6 +150,7 @@ mops outdated             # list outdated dependencies (caret-bound)
 mops update               # update all within caret bound (no major-version crossing)
 mops update core          # update specific package within caret bound
 mops update --major       # allow updates that cross major versions
+mops update --patch       # restrict to patch bumps only (mutually exclusive with --major)
 mops sync                 # add missing / remove unused packages
 ```
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Mops CLI Changelog
 
 ## Next
+- Add `--patch` to `mops update` and `mops outdated` to restrict updates to patch versions only (e.g. `1.2.3 -> 1.2.4`, never `1.2.3 -> 1.3.0`). Mutually exclusive with `--major`. For pre-1.0 packages this matches the default — caret already restricts `0.x.y` to patch updates. Useful for risk-averse upgrades on packages that have hit 1.0+.
+
 - Improve the per-file integrity-check error after `mops install --lock update`. Previously the message told users to run `mops install --lock update` — the exact command that just failed. After a regenerated lockfile, the only way a per-file hash can still mismatch is a local edit under `.mops/`, so the message now says that and suggests restoring from the global cache (delete the `.mops/<pkg>` directory and run `mops install`) or using a `repo`/`path` entry in `mops.toml` to keep custom changes.
 
 - Deprecate the `vessel.dhall` auto-migration in `mops init`. Behavior is unchanged for now — interactive `mops init` still reads `vessel.dhall` and copies its dependencies into `mops.toml` — but a warning is printed (also under `--yes`, which still skips the migration itself), and the migration will be removed in mops v3. Before then, copy your dependencies into `mops.toml` manually and delete `vessel.dhall` / `package-set.dhall`.

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -626,11 +626,19 @@ program
 // outdated
 program
   .command("outdated")
-  .description("Print outdated dependencies specified in mops.toml")
+  .description(
+    "Print outdated dependencies in mops.toml within the caret bound (does not cross major versions, or pre-1.0 minor versions)",
+  )
   .addOption(
     new Option(
       "--major",
       "Allow updates that cross the caret bound (major versions, or for 0.x.y packages, minor versions)",
+    ).conflicts("patch"),
+  )
+  .addOption(
+    new Option(
+      "--patch",
+      "Restrict updates to patch versions only (e.g. 1.2.3 -> 1.2.4, never 1.2.3 -> 1.3.0)",
     ),
   )
   .action(async (options) => {
@@ -640,11 +648,19 @@ program
 // update
 program
   .command("update [pkg]")
-  .description("Update dependencies specified in mops.toml")
+  .description(
+    "Update dependencies in mops.toml to the highest semver-compatible version within the caret bound (does not cross major versions, or pre-1.0 minor versions)",
+  )
   .addOption(
     new Option(
       "--major",
       "Allow updates that cross the caret bound (major versions, or for 0.x.y packages, minor versions)",
+    ).conflicts("patch"),
+  )
+  .addOption(
+    new Option(
+      "--patch",
+      "Restrict updates to patch versions only (e.g. 1.2.3 -> 1.2.4, never 1.2.3 -> 1.3.0)",
     ),
   )
   .addOption(

--- a/cli/commands/available-updates.ts
+++ b/cli/commands/available-updates.ts
@@ -6,7 +6,7 @@ import { Config } from "../types.js";
 import { getDepName, getDepPinnedVersion } from "../helpers/get-dep-name.js";
 import { SemverPart } from "../declarations/main/main.did.js";
 
-export type UpdateBound = "caret" | "major";
+export type UpdateBound = "patch" | "caret" | "major";
 
 // [pkg, oldVersion, newVersion]
 export async function getAvailableUpdates(
@@ -45,7 +45,9 @@ export async function getAvailableUpdates(
       let semverPart: SemverPart = { major: null };
       let name = getDepName(dep.name);
       let pinnedVersion = getDepPinnedVersion(dep.name);
-      if (pinnedVersion) {
+      if (bound === "patch") {
+        semverPart = { patch: null };
+      } else if (pinnedVersion) {
         semverPart =
           pinnedVersion.split(".").length === 1
             ? { minor: null }

--- a/cli/commands/outdated.ts
+++ b/cli/commands/outdated.ts
@@ -3,7 +3,10 @@ import { checkConfigFile, readConfig } from "../mops.js";
 import { getAvailableUpdates } from "./available-updates.js";
 import { getDepName, getDepPinnedVersion } from "../helpers/get-dep-name.js";
 
-export async function outdated({ major }: { major?: boolean } = {}) {
+export async function outdated({
+  major,
+  patch,
+}: { major?: boolean; patch?: boolean } = {}) {
   if (!checkConfigFile()) {
     return;
   }
@@ -12,7 +15,7 @@ export async function outdated({ major }: { major?: boolean } = {}) {
   let available = await getAvailableUpdates(
     config,
     undefined,
-    major ? "major" : "caret",
+    major ? "major" : patch ? "patch" : "caret",
   );
 
   if (available.length === 0) {

--- a/cli/commands/update.ts
+++ b/cli/commands/update.ts
@@ -15,11 +15,12 @@ type UpdateOptions = {
   dev?: boolean;
   lock?: "update" | "ignore";
   major?: boolean;
+  patch?: boolean;
 };
 
 export async function update(
   pkg?: string,
-  { lock, major }: UpdateOptions = {},
+  { lock, major, patch }: UpdateOptions = {},
 ) {
   if (!checkConfigFile()) {
     return;
@@ -66,7 +67,7 @@ export async function update(
   let available = await getAvailableUpdates(
     config,
     pkg,
-    major ? "major" : "caret",
+    major ? "major" : patch ? "patch" : "caret",
   );
 
   if (available.length === 0) {

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -325,3 +325,71 @@ describe("update / outdated bounds", () => {
     }
   });
 });
+
+// `--patch` restricts updates to patch versions only, never crossing the minor
+// bound. Fixture pins `core = "2.3.0"`; registry has 2.3.1 (patch) and 2.4.0,
+// 2.5.0 (minor). Caret default lets minors through; --patch must not.
+describe("update / outdated --patch bound", () => {
+  jest.setTimeout(120_000);
+
+  const cwd = path.join(import.meta.dirname, "install/update-bound-patch");
+  const tomlFile = path.join(cwd, "mops.toml");
+  const original = readFileSync(tomlFile, "utf8");
+
+  const cleanup = () => {
+    rmSync(path.join(cwd, "mops.lock"), { force: true });
+    rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+    writeFileSync(tomlFile, original);
+  };
+
+  const coreVersion = (toml: string) =>
+    toml.match(/core = "(\d+\.\d+\.\d+)"/)?.[1];
+
+  test("mops update --patch restricts to patch bumps", async () => {
+    cleanup();
+    try {
+      await cli(["install"], { cwd, env: { CI: undefined } });
+      const result = await cli(["update", "--patch"], {
+        cwd,
+        env: { CI: undefined },
+      });
+      expect(result.exitCode).toBe(0);
+      const after = readFileSync(tomlFile, "utf8");
+      // Stays within 2.3.x — must not cross to 2.4.0 / 2.5.0
+      expect(coreVersion(after)).toMatch(/^2\.3\./);
+      expect(coreVersion(after)).not.toBe("2.3.0");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("mops outdated --patch reports patch-only updates", async () => {
+    cleanup();
+    try {
+      await cli(["install"], { cwd, env: { CI: undefined } });
+      const patch = normalizePaths(
+        (await cli(["outdated", "--patch"], { cwd, env: { CI: undefined } }))
+          .stdout,
+      );
+      // Only 2.3.x updates surface, never 2.4.x / 2.5.x
+      expect(patch).toMatch(/core 2\.3\.0 -> 2\.3\./);
+      expect(patch).not.toMatch(/core 2\.3\.0 -> 2\.[4-9]/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test.each([["update"], ["outdated"]])(
+    "mops %s rejects --major + --patch",
+    async (cmd) => {
+      const result = await cli([cmd, "--major", "--patch"], {
+        cwd,
+        env: { CI: undefined },
+      });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toMatch(
+        /option '--major' cannot be used with option '--patch'/,
+      );
+    },
+  );
+});

--- a/cli/tests/install/update-bound-patch/mops.toml
+++ b/cli/tests/install/update-bound-patch/mops.toml
@@ -1,0 +1,2 @@
+[dependencies]
+core = "2.3.0"

--- a/docs/docs/cli/1-deps/03-mops-outdated.md
+++ b/docs/docs/cli/1-deps/03-mops-outdated.md
@@ -18,3 +18,12 @@ Also report updates that cross the caret bound. Mirrors [`mops update --major`](
 ```
 mops outdated --major
 ```
+
+### `--patch`
+
+Restrict reported updates to patch versions only. Mirrors [`mops update --patch`](/cli/mops-update#--patch).
+```
+mops outdated --patch
+```
+
+Mutually exclusive with [`--major`](#--major).

--- a/docs/docs/cli/1-deps/04-mops-update.md
+++ b/docs/docs/cli/1-deps/04-mops-update.md
@@ -30,6 +30,18 @@ Allow updates that cross the caret bound — major versions, or for `0.x.y` pack
 - `mops update core` → bumps within `2.x.y` (e.g. `2.5.0`)
 - `mops update core --major` → also allows `3.0.0` or later, once published
 
+Mutually exclusive with [`--patch`](#--patch).
+
+### `--patch`
+
+Restrict updates to patch versions only — never bumps minor or major. Useful for risk-averse upgrades. For example, with `core = "1.2.3"`:
+- `mops update core` → may bump to `1.5.0` (within `1.x.y`)
+- `mops update core --patch` → only bumps to `1.2.4`, `1.2.5`, … (never `1.3.0`)
+
+For `0.x.y` packages this matches the default — caret already restricts pre-1.0 packages to patch updates.
+
+Mutually exclusive with [`--major`](#--major).
+
 ### `--lock`
 
 What to do with the [lockfile](/mops.lock).


### PR DESCRIPTION
## What changes for users

`mops update` and `mops outdated` gain a `--patch` flag — the strict counterpart to `--major`. It restricts updates to patch versions only, never crossing the minor bound.

```
core = "2.3.0"          # registry has 2.3.1, 2.4.0, 2.5.0

mops update             # caret default: 2.3.0 -> 2.5.0
mops update --patch     # patch only:    2.3.0 -> 2.3.1
mops update --major     # any:           2.3.0 -> 2.5.0 (or 3.x if published)
```

For pre-1.0 packages this matches the caret default — caret already restricts `0.x.y` to patch updates. The flag's value comes once a package hits 1.0+: it's the safest possible upgrade, useful for risk-averse projects that only want bugfix bumps. Mutually exclusive with `--major`.

`mops update --help` and `mops outdated --help` were also missing context on what the default does — they now mention the caret bound:

```
Update dependencies in mops.toml to the highest semver-compatible version
within the caret bound (does not cross major versions, or pre-1.0 minor
versions)
```

## Why

Asymmetric flag set: `--major` was already there for the looser direction, but there was no way to be stricter than the caret default. Once `core` and other registry packages start crossing 1.0, users who pin a specific minor (e.g. `core = "2.3.0"`) and want only `2.3.x` bugfixes had no flag-based way to express that.


Made with [Cursor](https://cursor.com)