### PR TITLE
docs: list mops build outputs up front

### DIFF
--- a/docs/docs/cli/4-dev/03-mops-build.md
+++ b/docs/docs/cli/4-dev/03-mops-build.md
@@ -11,14 +11,17 @@ Build Motoko canisters defined in `mops.toml`
 mops build
 ```
 
-Compiles Motoko canisters to WebAssembly (Wasm) modules and generates Candid interface and Motoko stable types files.
+Compiles Motoko canisters to WebAssembly and generates their Candid interface and stable types files.
 
 Canisters must be defined in the `[canisters]` section of your `mops.toml` file.
 
-The build command will automatically:
-- Add Candid metadata to the Wasm modules
-- Generate a Motoko stable types file (`.most`) for each canister
-- Validate Candid compatibility (if a candid file is specified in canister config)
+For each canister, three files are written to the output directory (default `.mops/.build`):
+
+- `<canister>.wasm` — compiled WebAssembly module, with Candid metadata embedded
+- `<canister>.did` — generated Candid interface
+- `<canister>.most` — Motoko stable types signature (used for upgrade safety checking)
+
+If the canister config sets a `candid` field, the generated `.did` is also checked for compatibility against it.
 
 ### Examples
 


### PR DESCRIPTION
## Summary

The `mops build` docs page never clearly tells the reader which files the command produces. `.did` is only mentioned in passing inside the **Stable Types** section near the bottom (*"alongside the `.wasm` and `.did` files"*), and the intro bullets talk about *embedding* Candid metadata without saying a `.did` file is also written.

This came up via a [forum thread](https://forum.dfinity.org/t/icp-cli-announcements-and-feedback-discussion/60410/89) where users were manually invoking `moc --idl …` to produce a `.did`, not realising `mops build` already does it.

Surface `.wasm` / `.did` / `.most` explicitly in the intro so the artifact list is the first thing readers see.

### Before

> The build command will automatically:
> - Add Candid metadata to the Wasm modules
> - Generate a Motoko stable types file (`.most`) for each canister
> - Validate Candid compatibility (if a candid file is specified in canister config)

### After

> For each canister, three files are written to the output directory (default `.mops/.build`):
>
> - `<canister>.wasm` — compiled WebAssembly module, with Candid metadata embedded
> - `<canister>.did` — generated Candid interface
> - `<canister>.most` — Motoko stable types signature (used for upgrade safety checking)
>
> If the canister config sets a `candid` field, the generated `.did` is also checked for compatibility against it.

## Test plan

- [ ] Render the docs site locally and confirm the new bullets read correctly

Made with [Cursor](https://cursor.com)