### PR TITLE
chore(cli): list managed tools in `mops toolchain --help` and on missing/invalid `<tool>`

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Mops CLI Changelog
 
 ## Next
+- `mops toolchain --help` now lists the tools mops manages (`moc`, `wasmtime`, `pocket-ic`, `lintoko`) in the top-level description instead of only mentioning them under `bin`, and `mops toolchain use` / `update` / `bin` print the available tools (via the auto-generated help) when invoked with a missing or invalid `<tool>` argument.
+
 - Add `--patch` to `mops update` and `mops outdated` to restrict updates to patch versions only (e.g. `1.2.3 -> 1.2.4`, never `1.2.3 -> 1.3.0`). Mutually exclusive with `--major`. For pre-1.0 packages this matches the default — caret already restricts `0.x.y` to patch updates. Useful for risk-averse upgrades on packages that have hit 1.0+.
 
 - Improve the per-file integrity-check error after `mops install --lock update`. Previously the message told users to run `mops install --lock update` — the exact command that just failed. After a regenerated lockfile, the only way a per-file hash can still mismatch is a local edit under `.mops/`, so the message now says that and suggests restoring from the global cache (delete the `.mops/<pkg>` directory and run `mops install`) or using a `repo`/`path` entry in `mops.toml` to keep custom changes.

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -674,9 +674,11 @@ program
   });
 
 // toolchain
-const toolchainCommand = new Command("toolchain").description(
-  "Toolchain management",
-);
+const toolchainCommand = new Command("toolchain")
+  .description(
+    `Toolchain management for ${TOOLCHAINS.map((s) => `"${s}"`).join(", ")}`,
+  )
+  .showHelpAfterError();
 
 toolchainCommand
   .command("init")
@@ -695,8 +697,13 @@ toolchainCommand
 toolchainCommand
   .command("use")
   .description("Install specified tool version and update mops.toml")
-  .addArgument(new Argument("<tool>").choices(TOOLCHAINS))
-  .addArgument(new Argument("[version]"))
+  .addArgument(new Argument("<tool>", "tool to install").choices(TOOLCHAINS))
+  .addArgument(
+    new Argument(
+      "[version]",
+      "version to install (defaults to interactive picker)",
+    ),
+  )
   .action(async (tool, version) => {
     if (!checkConfigFile()) {
       process.exit(1);
@@ -709,7 +716,12 @@ toolchainCommand
   .description(
     "Update specified tool or all tools to the latest version and update mops.toml",
   )
-  .addArgument(new Argument("[tool]").choices(TOOLCHAINS))
+  .addArgument(
+    new Argument(
+      "[tool]",
+      "tool to update (defaults to all configured tools)",
+    ).choices(TOOLCHAINS),
+  )
   .action(async (tool?: Tool) => {
     if (!checkConfigFile()) {
       process.exit(1);
@@ -719,10 +731,8 @@ toolchainCommand
 
 toolchainCommand
   .command("bin")
-  .description(
-    `Get path to the tool binary\n<tool> can be one of ${TOOLCHAINS.map((s) => `"${s}"`).join(", ")}`,
-  )
-  .addArgument(new Argument("<tool>").choices(TOOLCHAINS))
+  .description("Get path to the tool binary")
+  .addArgument(new Argument("<tool>", "tool to look up").choices(TOOLCHAINS))
   .addOption(
     new Option(
       "--fallback",


### PR DESCRIPTION
## Why

Two small DX papercuts on `mops toolchain`:

1. The top-level `mops toolchain --help` did not list the tools mops manages. The only place that mentioned them was the description of `bin` — an inconsistency, since `use` and `update` take the same `<tool>` argument.
2. `mops toolchain use` (no args) failed with just `error: missing required argument 'tool'` — no hint at which tools are valid. Users had to dig through `--help` (which itself didn't show the choices) or trial-and-error with an invalid tool name to discover them.

## What changes for users

### `mops toolchain --help`

Before:

```
Usage: mops toolchain [options] [command]

Toolchain management

Options:
  -h, --help            display help for command

Commands:
  init                  One-time initialization of toolchain management
  reset                 Uninstall toolchain management
  use <tool> [version]  Install specified tool version and update mops.toml
  update [tool]         Update specified tool or all tools to the latest version
                        and update mops.toml
  bin [options] <tool>  Get path to the tool binary
                        <tool> can be one of "moc", "wasmtime", "pocket-ic",
                        "lintoko"
  help [command]        display help for command
```

After:

```
Usage: mops toolchain [options] [command]

Toolchain management for "moc", "wasmtime", "pocket-ic", "lintoko"

Options:
  -h, --help            display help for command

Commands:
  init                  One-time initialization of toolchain management
  reset                 Uninstall toolchain management
  use <tool> [version]  Install specified tool version and update mops.toml
  update [tool]         Update specified tool or all tools to the latest version
                        and update mops.toml
  bin [options] <tool>  Get path to the tool binary
  help [command]        display help for command
```

### `mops toolchain use` (missing / invalid `<tool>`)

Before:

```
$ mops toolchain use
error: missing required argument 'tool'
```

After:

```
$ mops toolchain use
error: missing required argument 'tool'

Usage: mops toolchain use [options] <tool> [version]

Install specified tool version and update mops.toml

Arguments:
  tool        tool to install (choices: "moc", "wasmtime", "pocket-ic",
              "lintoko")
  version     version to install (defaults to interactive picker)

Options:
  -h, --help  display help for command
```

Same treatment for `mops toolchain update` and `mops toolchain bin`.

## Implementation

- Moved the tool list from `bin`'s description into the parent `toolchain` description (single source of truth).
- Added argument descriptions for `<tool>` / `[tool]` / `[version]` so Commander renders the `Arguments:` block with `(choices: ...)`.
- Enabled `showHelpAfterError()` on the parent command — inherited by every subcommand via Commander's `copyInheritedSettings`.

## Test plan

- [x] `npm run check` (cli + frontend) clean
- [x] `npm test -- toolchain.test.ts` — 3/3 pass
- [x] Manually verified the help and error output for `mops toolchain`, `mops toolchain use`, `mops toolchain update`, `mops toolchain bin` (with and without args, valid and invalid tool names)

Made with [Cursor](https://cursor.com)