### PR TITLE
fix(cli): prevent `check --fix` crash when moc produces no output

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Mops CLI Changelog
 
 ## Next
+- Fix `mops check --fix` crashing with `TypeError: Cannot read properties of undefined (reading 'split')` when `moc` produces no output (e.g. it fails to spawn or is killed by the OOM killer in a memory-constrained container). The autofix pass now treats missing `moc` output as "no fixes to apply" and lets the regular check report the real failure, instead of aborting the whole command with an unhandled exception.
+
 - Fix `mops check --fix` and `mops lint --fix` corrupting source files when two `mops` processes run concurrently in the same project (e.g. two coding agents on the same checkout). Concurrent runs could apply stale `moc` byte offsets to a sibling's already-mutated file, leaving source like `let nat = identity` (with the type-arg and call dropped) or `list.sortInPlace(` with an unclosed paren. `--fix` invocations now acquire a project-root advisory lock at `.mops/fix.lock` and serialize, cargo-style ("Waiting for another `mops --fix` run to finish..."). Read-only `mops check` and `mops lint` are unchanged.
 
 - Deprecate the `dfx` replica in `mops bench`, `mops test --mode replica`, and `mops watch`. Behavior is unchanged — `--replica dfx`, the implicit `dfx` fallback when no `[toolchain.pocket-ic]` is set, and the dfx-bundled PocketIC fallback all still work — but each now prints a warning. Run `mops toolchain use pocket-ic <version>` to silence it. The `dfx` paths will be removed and the default flipped to PocketIC in mops v3 — `dfx` is being deprecated upstream and PocketIC is a better fit for benchmarks and replica tests (deterministic, in-process, no background daemon).

--- a/cli/helpers/autofix-motoko.ts
+++ b/cli/helpers/autofix-motoko.ts
@@ -26,7 +26,10 @@ export interface MocDiagnostic {
   notes: string[];
 }
 
-export function parseDiagnostics(stdout: string): MocDiagnostic[] {
+export function parseDiagnostics(stdout: string | undefined): MocDiagnostic[] {
+  if (!stdout) {
+    return [];
+  }
   return stdout
     .split("\n")
     .filter((l) => l.trim())

--- a/cli/tests/check-fix.test.ts
+++ b/cli/tests/check-fix.test.ts
@@ -62,6 +62,13 @@ describe("check --fix", () => {
     return runFilePath;
   }
 
+  test("parseDiagnostics tolerates missing moc output", () => {
+    // execa with reject:false yields undefined stdout when moc fails to spawn
+    // or is killed (e.g. OOM); parsing must degrade to no diagnostics, not throw.
+    expect(parseDiagnostics(undefined)).toEqual([]);
+    expect(parseDiagnostics("")).toEqual([]);
+  });
+
   test("M0223", async () => {
     await testCheckFix("M0223.mo", { M0223: 1 });
   });


### PR DESCRIPTION
## What changes for users

`mops check --fix` no longer crashes when `moc` produces no output. Previously the autofix pass aborted the entire command with an unhandled exception:

```
TypeError: Cannot read properties of undefined (reading 'split')
    at parseDiagnostics (.../dist/helpers/autofix-motoko.js)
```

This was blocking deployments in memory-constrained environments (CI/containers) where `moc` can fail to spawn or get OOM-killed — `execa(..., { reject: false })` then resolves with `stdout === undefined`. Even unrelated frontend-only changes couldn't ship because the backend `check --fix` step crashed.

## Why

`parseDiagnostics(stdout: string)` assumed `moc` always returns captured stdout. With `reject: false`, a failed/killed `moc` yields `undefined`, and `.split()` threw. Reported by multiple users in production.

**Before:** any `moc` spawn/kill failure during `--fix` → hard crash, command aborts.
**After:** missing output is treated as "no fixes to apply"; the subsequent regular check reports the real failure (e.g. non-zero exit) with a clear message.

## Notes

Targeted unit test added for the `undefined` / empty stdout paths.

Made with [Cursor](https://cursor.com)