### PR TITLE
release: CLI v2.14.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Mops CLI Changelog
 
 ## Next
+
+## 2.14.0
 - Fix `mops check --fix` crashing with `TypeError: Cannot read properties of undefined (reading 'split')` when `moc` produces no output (e.g. it fails to spawn or is killed by the OOM killer in a memory-constrained container). The autofix pass now treats missing `moc` output as "no fixes to apply" and lets the regular check report the real failure, instead of aborting the whole command with an unhandled exception.
 
 - Fix `mops check --fix` and `mops lint --fix` corrupting source files when two `mops` processes run concurrently in the same project (e.g. two coding agents on the same checkout). Concurrent runs could apply stale `moc` byte offsets to a sibling's already-mutated file, leaving source like `let nat = identity` (with the type-arg and call dropped) or `list.sortInPlace(` with an unclosed paren. `--fix` invocations now acquire a project-root advisory lock at `.mops/fix.lock` and serialize, cargo-style ("Waiting for another `mops --fix` run to finish..."). Read-only `mops check` and `mops lint` are unchanged.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ic-mops",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ic-mops",
-      "version": "2.13.2",
+      "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
         "@icp-sdk/core": "4.0.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-mops",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "type": "module",
   "bin": {
     "mops": "dist/bin/mops.js",


### PR DESCRIPTION
Release CLI v2.14.0.

Highlights:
- **New:** `mops update --patch` / `mops outdated --patch` for patch-only upgrades.
- **Fixes:** `mops check --fix` crash on empty `moc` output; source corruption from concurrent `--fix` runs; `mops install` races under parallel invocations.
- **Deprecations (v3):** `dfx` replica in `bench`/`test`/`watch`; `vessel.dhall` auto-migration in `init`.
- **Internal:** swap `@iarna/toml` for `smol-toml`; clearer integrity-check error; `mops toolchain --help` lists managed tools.

See `cli/CHANGELOG.md` for full notes.

Made with [Cursor](https://cursor.com)