### PR TITLE
fix(frontend): serve .well-known/ic-domains at the correct path

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "DFX_NETWORK=${DFX_NETWORK:-local} vite --port 3000",
     "vite": "vite",
-    "build": "vite build",
+    "build": "vite build && node verify-build.mjs",
     "preview": "vite preview",
     "check": "svelte-check --threshold error"
   },

--- a/frontend/verify-build.mjs
+++ b/frontend/verify-build.mjs
@@ -1,0 +1,22 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+// Assets that must exist at an exact path in the build output. Guards against
+// vite-plugin-static-copy glob/dest changes silently relocating them — a
+// misplaced .well-known/ic-domains breaks mops.one custom-domain certs.
+const required = [
+  ".well-known/ic-domains",
+  "external/onig@1.7.0.wasm",
+  "external/gfm-table.css",
+  ".ic-assets.json",
+];
+
+const dist = path.resolve(import.meta.dirname, "dist");
+const missing = required.filter((p) => !existsSync(path.join(dist, p)));
+
+if (missing.length) {
+  console.error(
+    `\n✗ Build output missing expected assets in dist/:\n${missing.map((p) => `  - ${p}`).join("\n")}\n`,
+  );
+  process.exit(1);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -76,7 +76,7 @@ export default defineConfig({
       targets: [
         {
           src: "external/*",
-          dest: "external",
+          dest: ".",
         },
         {
           src: ".ic-assets.json",
@@ -84,7 +84,7 @@ export default defineConfig({
         },
         {
           src: ".well-known/*",
-          dest: ".well-known",
+          dest: ".",
         },
       ],
     }),


### PR DESCRIPTION
## What & why

The `mops.one` custom-domain certificate renewal was failing because the boundary node couldn't find `/.well-known/ic-domains` on the assets canister (`j4mwm-bqaaa-aaaam-qajbq-cai`):

```
curl https://j4mwm-bqaaa-aaaam-qajbq-cai.icp0.io/.well-known/ic-domains        → 404
curl https://j4mwm-bqaaa-aaaam-qajbq-cai.icp0.io/.well-known/.well-known/ic-domains → 200
```

The asset was deployed one directory too deep. `vite-plugin-static-copy` v4 (picked up in the recent Vite 8 / tooling upgrade) preserves the matched glob directory, so `{ src: ".well-known/*", dest: ".well-known" }` now emits `dist/.well-known/.well-known/ic-domains`.

The same regression hit `external/*` → `dist/external/external/*`, while the app references the **flat** paths `/external/onig@1.7.0.wasm` (starry-night syntax-highlighting wasm) and `./external/gfm-table.css` — both silently broken in production.

## Fix

Point the glob copy targets at the dist root so files land flat:

| path | before | after |
|---|---|---|
| ic-domains | `/.well-known/.well-known/ic-domains` | `/.well-known/ic-domains` |
| onig wasm | `/external/external/onig@1.7.0.wasm` | `/external/onig@1.7.0.wasm` |
| gfm-table.css | `/external/external/gfm-table.css` | `/external/gfm-table.css` |

## Follow-up after merge

1. Deploy the frontend to `ic`.
2. Verify `curl https://j4mwm-bqaaa-aaaam-qajbq-cai.icp0.io/.well-known/ic-domains` returns the domain list.
3. Ask DFINITY (Rüdiger) to trigger custom-domain re-registration.

> Note: `play-frontend`, `cli-releases`, `docs`, and `blog` serve `.well-known/ic-domains` from their source roots (no `viteStaticCopy`), so they were unaffected.

Made with [Cursor](https://cursor.com)

## Regression guard

`frontend/verify-build.mjs` runs after every build (local, CI, dfx deploy hook) and fails if `.well-known/ic-domains` or the `external/*` assets land at the wrong path — no test framework needed.
