### PR TITLE
perf(cli): check all files in a single moc invocation

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mops CLI Changelog
 
 ## Next
+- Speed up `mops check <files...>` (e.g. `mops check src/**/*.mo`) on packages with many files. Previously each file was checked in its own `moc` invocation, so every shared transitive import was re-parsed and re-type-checked once per file. All files are now passed to a single `moc --check` call, which loads and type-checks each import only once — on motoko-core (53 files) this drops a full check from ~27s to ~1.6s. The per-file `✓` confirmations now print only when the whole check passes.
 
 ## 2.14.0
 - Fix `mops check --fix` crashing with `TypeError: Cannot read properties of undefined (reading 'split')` when `moc` produces no output (e.g. it fails to spawn or is killed by the OOM killer in a memory-constrained container). The autofix pass now treats missing `moc` output as "no fixes to apply" and lets the regular check report the real failure, instead of aborting the whole command with an unhandled exception.

--- a/cli/commands/check.ts
+++ b/cli/commands/check.ts
@@ -262,30 +262,30 @@ async function checkFiles(
     logAutofixResult(fixResult, options.verbose);
   }
 
-  for (const file of files) {
-    try {
-      const args = [file, ...mocArgs];
-      if (options.verbose) {
-        console.log(chalk.blue("check"), chalk.gray("Running moc:"));
-        console.log(chalk.gray(mocPath, JSON.stringify(args)));
-      }
+  // Check all files in a single moc invocation so shared transitive imports
+  // are chased and type-checked once, not re-checked for every file.
+  const args = [...files, ...mocArgs];
+  if (options.verbose) {
+    console.log(chalk.blue("check"), chalk.gray("Running moc:"));
+    console.log(chalk.gray(mocPath, JSON.stringify(args)));
+  }
 
-      const result = await execa(mocPath, args, {
-        stdio: "inherit",
-        reject: false,
-      });
+  try {
+    const result = await execa(mocPath, args, {
+      stdio: "inherit",
+      reject: false,
+    });
 
-      if (result.exitCode !== 0) {
-        cliError(
-          `✗ Check failed for file ${file} (exit code: ${result.exitCode})`,
-        );
-      }
-
-      console.log(chalk.green(`✓ ${file}`));
-    } catch (err: any) {
-      cliError(
-        `Error while checking ${file}${err?.message ? `\n${err.message}` : ""}`,
-      );
+    if (result.exitCode !== 0) {
+      cliError(`✗ Check failed (exit code: ${result.exitCode})`);
     }
+  } catch (err: any) {
+    cliError(
+      `Error while checking files${err?.message ? `\n${err.message}` : ""}`,
+    );
+  }
+
+  for (const file of files) {
+    console.log(chalk.green(`✓ ${file}`));
   }
 }

--- a/cli/helpers/autofix-motoko.ts
+++ b/cli/helpers/autofix-motoko.ts
@@ -184,19 +184,18 @@ export async function autofixMotoko(
   for (let iteration = 0; iteration < MAX_FIX_ITERATIONS; iteration++) {
     const fixesByFile = new Map<string, DiagnosticFix[]>();
 
-    for (const file of files) {
-      const result = await execa(
-        mocPath,
-        [file, ...mocArgs, "--error-format=json"],
-        { stdio: "pipe", reject: false },
-      );
+    // Single invocation: moc dedups shared imports across all files.
+    const result = await execa(
+      mocPath,
+      [...files, ...mocArgs, "--error-format=json"],
+      { stdio: "pipe", reject: false },
+    );
 
-      const diagnostics = parseDiagnostics(result.stdout);
-      for (const [targetFile, fixes] of extractDiagnosticFixes(diagnostics)) {
-        const existing = fixesByFile.get(targetFile) ?? [];
-        existing.push(...fixes);
-        fixesByFile.set(targetFile, existing);
-      }
+    const diagnostics = parseDiagnostics(result.stdout);
+    for (const [targetFile, fixes] of extractDiagnosticFixes(diagnostics)) {
+      const existing = fixesByFile.get(targetFile) ?? [];
+      existing.push(...fixes);
+      fixesByFile.set(targetFile, existing);
     }
 
     if (fixesByFile.size === 0) {

--- a/cli/tests/__snapshots__/check.test.ts.snap
+++ b/cli/tests/__snapshots__/check.test.ts.snap
@@ -5,7 +5,7 @@ exports[`check [moc] args are passed to moc 1`] = `
   "exitCode": 1,
   "stderr": "Warning.mo:3.9-3.15: warning [M0194], unused identifier: \`unused\`
 help: if this is intentional, prefix it with an underscore: \`_unused\`
-✗ Check failed for file Warning.mo (exit code: 1)",
+✗ Check failed (exit code: 1)",
   "stdout": "",
 }
 `;
@@ -18,7 +18,7 @@ exports[`check error 1`] = `
 cannot produce expected type
   ()
 Error.mo:7.1-7.21: type error [M0057], unbound variable thisshouldnotcompile
-✗ Check failed for file Error.mo (exit code: 1)",
+✗ Check failed (exit code: 1)",
   "stdout": "",
 }
 `;
@@ -27,8 +27,21 @@ exports[`check error 2`] = `
 {
   "exitCode": 1,
   "stderr": "Ok.mo: No such file or directory
-✗ Check failed for file Ok.mo (exit code: 1)",
+✗ Check failed (exit code: 1)",
   "stdout": "",
+}
+`;
+
+exports[`check multiple files in a single invocation 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "Warning.mo:3.9-3.15: warning [M0194], unused identifier: \`unused\`
+help: if this is intentional, prefix it with an underscore: \`_unused\`",
+  "stdout": "check Using --all-libs for richer diagnostics
+check Running moc:
+<CACHE>moc-wrapper ["Ok.mo","Warning.mo","--check","--all-libs","--default-persistent-actors"]
+✓ Ok.mo
+✓ Warning.mo",
 }
 `;
 
@@ -85,7 +98,7 @@ exports[`check warning with -Werror flag 1`] = `
   "exitCode": 1,
   "stderr": "Warning.mo:3.9-3.15: warning [M0194], unused identifier: \`unused\`
 help: if this is intentional, prefix it with an underscore: \`_unused\`
-✗ Check failed for file Warning.mo (exit code: 1)",
+✗ Check failed (exit code: 1)",
   "stdout": "",
 }
 `;

--- a/cli/tests/check.test.ts
+++ b/cli/tests/check.test.ts
@@ -15,6 +15,17 @@ describe("check", () => {
     await cliSnapshot(["check", "Ok.mo", "Error.mo"], { cwd }, 1);
   });
 
+  // The verbose snapshot shows a single "moc ... [both files]" line, proving the
+  // whole set is checked in one invocation rather than one moc call per file.
+  test("multiple files in a single invocation", async () => {
+    const cwd = path.join(import.meta.dirname, "check/success");
+    await cliSnapshot(
+      ["check", "Ok.mo", "Warning.mo", "--verbose"],
+      { cwd },
+      0,
+    );
+  });
+
   test("warning", async () => {
     const cwd = path.join(import.meta.dirname, "check/success");
     const result = await cliSnapshot(["check", "Warning.mo"], { cwd }, 0);


### PR DESCRIPTION
## What changes for users

`mops check <files...>` (e.g. `mops check src/**/*.mo`) is dramatically faster on packages with many files. On [motoko-core](https://github.com/dfinity/motoko-core) (53 files) a full check drops from **~27s to ~1.6s**.

## Why

`mops check` invoked `moc --check` **once per file**. `moc` chases and type-checks transitive imports on every invocation, so a library imported across the package was re-parsed and re-type-checked once for every file that (directly or transitively) pulls it in — most of the work was redundant.

`moc --check` already accepts multiple files and dedupes shared imports within a single run (each lib loaded once, each input file checked once). The fix simply passes all files to one invocation. The same batching is applied to the `--fix` autofix pass.

## Behavior notes

- On failure, the per-file `✓` confirmations are no longer printed mid-run — they print only when the whole check passes. The failure footer changed from `✗ Check failed for file <X>` to `✗ Check failed`; `moc`'s own `file:line` diagnostics still identify the offending file.
- `mops watch`'s per-file parallel checkers are intentionally left as-is (they drive per-file TUI progress).

Made with [Cursor](https://cursor.com)