### PR TITLE
Revert "perf(cli): check all files in a single moc invocation" (#575)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Mops CLI Changelog
 
 ## Next
+- Revert "Speed up `mops check <files...>`" (2.14.1). Passing all files to a single `moc --check` invocation accumulates scope across them: checking `A.mo B.mo` makes `A.mo`'s definitions visible while type-checking `B.mo`, so a file that only compiles because a sibling brings something into scope is wrongly reported as passing. `mops check` again checks each file in its own `moc` invocation so every file is validated in isolation.
+
 - Add `--no-check-limit` to `mops check`, `mops check-stable`, and `mops lint` to process the full migration chain for a single run, ignoring the configured `[canisters.<name>.migrations].check-limit`. Handy for `mops check --fix --no-check-limit` to autofix issues in older migrations that the limit normally skips
 
 - `--help` now lists every option and the `-- <tool flags>` passthrough for each command: `mops build`, `mops check`, `mops check-stable`, and `mops generate candid` document `-- <moc flags>` (e.g. `mops check -- -Werror`), `mops lint` documents `-- <lintoko flags>`, and the `--verbose` flag of `mops add`/`mops install`/`mops publish` now has a description instead of showing blank

--- a/cli/commands/check.ts
+++ b/cli/commands/check.ts
@@ -266,30 +266,30 @@ async function checkFiles(
     logAutofixResult(fixResult, options.verbose);
   }
 
-  // Check all files in a single moc invocation so shared transitive imports
-  // are chased and type-checked once, not re-checked for every file.
-  const args = [...files, ...mocArgs];
-  if (options.verbose) {
-    console.log(chalk.blue("check"), chalk.gray("Running moc:"));
-    console.log(chalk.gray(mocPath, JSON.stringify(args)));
-  }
-
-  try {
-    const result = await execa(mocPath, args, {
-      stdio: "inherit",
-      reject: false,
-    });
-
-    if (result.exitCode !== 0) {
-      cliError(`✗ Check failed (exit code: ${result.exitCode})`);
-    }
-  } catch (err: any) {
-    cliError(
-      `Error while checking files${err?.message ? `\n${err.message}` : ""}`,
-    );
-  }
-
   for (const file of files) {
-    console.log(chalk.green(`✓ ${file}`));
+    try {
+      const args = [file, ...mocArgs];
+      if (options.verbose) {
+        console.log(chalk.blue("check"), chalk.gray("Running moc:"));
+        console.log(chalk.gray(mocPath, JSON.stringify(args)));
+      }
+
+      const result = await execa(mocPath, args, {
+        stdio: "inherit",
+        reject: false,
+      });
+
+      if (result.exitCode !== 0) {
+        cliError(
+          `✗ Check failed for file ${file} (exit code: ${result.exitCode})`,
+        );
+      }
+
+      console.log(chalk.green(`✓ ${file}`));
+    } catch (err: any) {
+      cliError(
+        `Error while checking ${file}${err?.message ? `\n${err.message}` : ""}`,
+      );
+    }
   }
 }

--- a/cli/helpers/autofix-motoko.ts
+++ b/cli/helpers/autofix-motoko.ts
@@ -184,18 +184,19 @@ export async function autofixMotoko(
   for (let iteration = 0; iteration < MAX_FIX_ITERATIONS; iteration++) {
     const fixesByFile = new Map<string, DiagnosticFix[]>();
 
-    // Single invocation: moc dedups shared imports across all files.
-    const result = await execa(
-      mocPath,
-      [...files, ...mocArgs, "--error-format=json"],
-      { stdio: "pipe", reject: false },
-    );
+    for (const file of files) {
+      const result = await execa(
+        mocPath,
+        [file, ...mocArgs, "--error-format=json"],
+        { stdio: "pipe", reject: false },
+      );
 
-    const diagnostics = parseDiagnostics(result.stdout);
-    for (const [targetFile, fixes] of extractDiagnosticFixes(diagnostics)) {
-      const existing = fixesByFile.get(targetFile) ?? [];
-      existing.push(...fixes);
-      fixesByFile.set(targetFile, existing);
+      const diagnostics = parseDiagnostics(result.stdout);
+      for (const [targetFile, fixes] of extractDiagnosticFixes(diagnostics)) {
+        const existing = fixesByFile.get(targetFile) ?? [];
+        existing.push(...fixes);
+        fixesByFile.set(targetFile, existing);
+      }
     }
 
     if (fixesByFile.size === 0) {

--- a/cli/tests/__snapshots__/check.test.ts.snap
+++ b/cli/tests/__snapshots__/check.test.ts.snap
@@ -5,7 +5,7 @@ exports[`check [moc] args are passed to moc 1`] = `
   "exitCode": 1,
   "stderr": "Warning.mo:3.9-3.15: warning [M0194], unused identifier: \`unused\`
 help: if this is intentional, prefix it with an underscore: \`_unused\`
-✗ Check failed (exit code: 1)",
+✗ Check failed for file Warning.mo (exit code: 1)",
   "stdout": "",
 }
 `;
@@ -18,7 +18,7 @@ exports[`check error 1`] = `
 cannot produce expected type
   ()
 Error.mo:7.1-7.21: type error [M0057], unbound variable thisshouldnotcompile
-✗ Check failed (exit code: 1)",
+✗ Check failed for file Error.mo (exit code: 1)",
   "stdout": "",
 }
 `;
@@ -27,21 +27,8 @@ exports[`check error 2`] = `
 {
   "exitCode": 1,
   "stderr": "Ok.mo: No such file or directory
-✗ Check failed (exit code: 1)",
+✗ Check failed for file Ok.mo (exit code: 1)",
   "stdout": "",
-}
-`;
-
-exports[`check multiple files in a single invocation 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "Warning.mo:3.9-3.15: warning [M0194], unused identifier: \`unused\`
-help: if this is intentional, prefix it with an underscore: \`_unused\`",
-  "stdout": "check Using --all-libs for richer diagnostics
-check Running moc:
-<CACHE>moc-wrapper ["Ok.mo","Warning.mo","--check","--all-libs","--default-persistent-actors"]
-✓ Ok.mo
-✓ Warning.mo",
 }
 `;
 
@@ -98,7 +85,7 @@ exports[`check warning with -Werror flag 1`] = `
   "exitCode": 1,
   "stderr": "Warning.mo:3.9-3.15: warning [M0194], unused identifier: \`unused\`
 help: if this is intentional, prefix it with an underscore: \`_unused\`
-✗ Check failed (exit code: 1)",
+✗ Check failed for file Warning.mo (exit code: 1)",
   "stdout": "",
 }
 `;

--- a/cli/tests/check.test.ts
+++ b/cli/tests/check.test.ts
@@ -15,17 +15,6 @@ describe("check", () => {
     await cliSnapshot(["check", "Ok.mo", "Error.mo"], { cwd }, 1);
   });
 
-  // The verbose snapshot shows a single "moc ... [both files]" line, proving the
-  // whole set is checked in one invocation rather than one moc call per file.
-  test("multiple files in a single invocation", async () => {
-    const cwd = path.join(import.meta.dirname, "check/success");
-    await cliSnapshot(
-      ["check", "Ok.mo", "Warning.mo", "--verbose"],
-      { cwd },
-      0,
-    );
-  });
-
   test("warning", async () => {
     const cwd = path.join(import.meta.dirname, "check/success");
     const result = await cliSnapshot(["check", "Warning.mo"], { cwd }, 0);


### PR DESCRIPTION
## What changes for users

`mops check <files...>` once again type-checks each file in its own `moc` invocation, restoring per-file isolation.

## Why

#575 passed all files to a single `moc --check A.mo B.mo ...` call for speed. But `moc` accumulates scope across the files it's given: while checking `B.mo`, every definition from `A.mo` is in scope. So a file that only "compiles" because a sibling earlier in the list brings something into scope is wrongly reported as passing — `mops check` could green-light code that fails when each file is checked on its own (or built normally).

Correctness of `mops check` matters more than the speedup, so this reverts to one `moc` invocation per file. The `--fix` autofix pass is likewise back to per-file.

## Notes

- The released v2.14.1 changelog entry is left intact (it records what shipped); a new `## Next` entry documents the revert and the reason.
- `mops watch`'s per-file checkers were never changed by #575.

If the speedup is revisited, it needs a `moc` mode that checks each input file in an isolated scope (not shared accumulation).

Made with [Cursor](https://cursor.com)