### PR TITLE
feat(cli): make `mops bench --verbose` actually verbose

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- `mops bench --verbose` is now actually verbose. It prints the benchmark pipeline up front — compiler version, replica + version, GC, profile, and whether the wasm is optimized (`dfx` post-optimizes with `optimize: "cycles"` via ic-wasm on deploy; `pocket-ic` runs the raw `moc` output) — logs the full `moc` build command, and streams the compiler and `dfx` output instead of capturing and discarding it. Notably this surfaces dfx's `WARNING: Failed to optimize the Wasm module`, which dfx prints (and then silently deploys the unoptimized module) when `optimize: "cycles"` fails — e.g. on multi-value modules that the bundled ic-wasm can't process. Previously all of this was hidden even with `--verbose`.
+
 ## 2.15.0
 
 - Fix `mops check --fix` corrupting source on lines containing multi-byte UTF-8 characters (e.g. `Char.toNat32('京')` dropping its trailing `)`). The autofixer was feeding moc's UTF-8 byte columns into LSP's UTF-16 position API, mis-applying every edit past the first non-ASCII byte on the line. When moc emits `byte_start`/`byte_end` (1.10.0 and newer) the fixer now applies edits byte-accurately; older moc still falls back to the line+column path (unchanged behavior, still ASCII-only).

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -543,7 +543,12 @@ program
     ),
   )
   // .addOption(new Option('--force-gc', 'Force GC'))
-  .addOption(new Option("--verbose", "Show more information"))
+  .addOption(
+    new Option(
+      "--verbose",
+      "Print the benchmark pipeline (compiler, replica, GC, optimization) and stream compiler/replica output, including dfx optimization warnings",
+    ),
+  )
   .action(async (filter, options) => {
     checkConfigFile(true);
     await installAll({

--- a/cli/commands/bench-replica.ts
+++ b/cli/commands/bench-replica.ts
@@ -74,7 +74,8 @@ export class BenchReplica {
     if (this.type === "dfx" || this.type === "dfx-pocket-ic") {
       await execaCommand(
         `dfx deploy ${name} --mode reinstall --yes --identity anonymous`,
-        { cwd, stdio: this.verbose ? "pipe" : ["pipe", "ignore", "pipe"] },
+        // `inherit` so dfx output is streamed under --verbose (incl. its `Failed to optimize` warning)
+        { cwd, stdio: this.verbose ? "inherit" : ["pipe", "ignore", "pipe"] },
       );
       let canisterId = execSync(`dfx canister id ${name}`, { cwd })
         .toString()

--- a/cli/commands/bench.ts
+++ b/cli/commands/bench.ts
@@ -101,7 +101,28 @@ export async function bench(
 
   warnIfDfxReplica(replicaType, optionsArg.replica === "dfx");
 
-  options.verbose && console.log(options);
+  if (options.verbose) {
+    // `dfx` post-optimizes the wasm on deploy (`optimize: "cycles"`, via ic-wasm);
+    // `pocket-ic` runs the raw moc output. This changes instruction counts, so surface it.
+    let optimize =
+      replicaType === "dfx" || replicaType === "dfx-pocket-ic"
+        ? 'dfx `optimize: "cycles"` (ic-wasm) on deploy'
+        : "none (raw moc output)";
+    console.log(chalk.gray("Benchmark pipeline:"));
+    console.log(chalk.gray(`  compiler:  moc ${options.compilerVersion}`));
+    console.log(
+      chalk.gray(
+        `  replica:   ${replicaType}${options.replicaVersion ? ` ${options.replicaVersion}` : ""}`,
+      ),
+    );
+    console.log(
+      chalk.gray(
+        `  gc:        ${options.gc}${options.forceGc ? " (forced)" : ""}`,
+      ),
+    );
+    console.log(chalk.gray(`  profile:   ${options.profile}`));
+    console.log(chalk.gray(`  optimize:  ${optimize}`));
+  }
 
   let replica = new BenchReplica(replicaType, options.verbose);
 
@@ -303,14 +324,16 @@ async function deployBenchFile(
   // build canister
   let mocPath = getMocPath();
   let mocArgs = getMocArgs(options);
-  options.verbose && console.time(`build ${canisterName}`);
-  await execaCommand(
-    `${mocPath} -c --idl canister.mo ${globalMocArgs.join(" ")} ${mocArgs} ${(await sources({ cwd: tempDir })).join(" ")}`,
-    {
-      cwd: tempDir,
-      stdio: options.verbose ? "pipe" : ["pipe", "ignore", "pipe"],
-    },
-  );
+  let buildCmd = `${mocPath} -c --idl canister.mo ${globalMocArgs.join(" ")} ${mocArgs} ${(await sources({ cwd: tempDir })).join(" ")}`;
+  if (options.verbose) {
+    console.log(chalk.gray(`[${canisterName}] ${buildCmd}`));
+    console.time(`build ${canisterName}`);
+  }
+  await execaCommand(buildCmd, {
+    cwd: tempDir,
+    // `inherit` so the compiler output (warnings/errors) is streamed under --verbose
+    stdio: options.verbose ? "inherit" : ["pipe", "ignore", "pipe"],
+  });
   options.verbose && console.timeEnd(`build ${canisterName}`);
 
   // deploy canister

--- a/docs/docs/cli/4-dev/02-mops-bench.md
+++ b/docs/docs/cli/4-dev/02-mops-bench.md
@@ -26,6 +26,19 @@ Under the hood, Mops will:
 - Run each cell of the benchmark file as an update call
 - For each call measure usage of wasm instructions(`performance_counter`) and heap size(`rts_heap_size`)
 
+:::caution Instruction counts depend on the replica
+
+The number you get is for the exact wasm the chosen replica runs, and the two replicas install it differently:
+
+- **`pocket-ic`** runs the raw `moc` output — **no optimization**.
+- **`dfx`** post-optimizes the module before installing it (`optimize: "cycles"`, via `ic-wasm`), so its instruction counts can be meaningfully lower.
+
+The same benchmark can therefore report different numbers across replicas. Always compare runs made with the **same replica**.
+
+Also note that `dfx`'s optimization is best-effort: if it fails (for example, on wasm modules using features the bundled `ic-wasm` can't process, such as multi-value), `dfx` prints `WARNING: Failed to optimize the Wasm module` and falls back to the **unoptimized** module. Run with [`--verbose`](#--verbose) to see this warning.
+
+:::
+
 ## Options
 
 ### `--replica`
@@ -58,4 +71,4 @@ Compare benchmark results with the results from `.bench/<filename>.json` file.
 
 ### `--verbose`
 
-Verbose output.
+Print the benchmark pipeline up front — compiler version, replica + version, GC, profile, and whether the wasm is optimized — then log the full `moc` build command and stream the compiler and `dfx` output (including any deploy/optimization warnings) instead of hiding it.


### PR DESCRIPTION
`mops bench --verbose` printed almost nothing useful: it dumped the raw options object, hid the `moc` build command, and captured the compiler/replica subprocess output without ever showing it. So when a benchmark behaved unexpectedly, `--verbose` was no help in diagnosing why.

That gap is exactly how a recent "+20% instructions after the moc 1.10.0 bump" report stayed a mystery for a day: the bench ran on the `dfx` replica, whose `optimize: "cycles"` step silently failed on moc's new multi-value output and fell back to the unoptimized module. dfx prints `WARNING: Failed to optimize the Wasm module` to stderr — but mops captured and discarded it, even under `--verbose`.

Now `--verbose` prints the pipeline up front and streams subprocess output.

**Before** — the raw options object, then silence:

```
{
  replica: 'pocket-ic', replicaVersion: '14.0.0',
  compiler: 'moc', compilerVersion: '1.9.0',
  gc: 'copying', forceGc: true, profile: 'Release', ...
}
```

**After:**

```
Benchmark pipeline:
  compiler:  moc 1.9.0
  replica:   pocket-ic 14.0.0
  gc:        copying (forced)
  profile:   Release
  optimize:  none (raw moc output)
[sha256.bench] moc-wrapper -c --idl canister.mo ... --release ...
build sha256.bench: 1.335s
```

On the `dfx` replica the `optimize:` line instead reads ``dfx `optimize: "cycles"` (ic-wasm) on deploy``, and dfx's own output — including the `Failed to optimize` warning — now streams through (the moc compile and `dfx deploy` use `inherit` instead of `pipe` under `--verbose`).

The docs page gains a caution that instruction counts depend on the replica — `pocket-ic` runs the raw `moc` output while `dfx` post-optimizes (`optimize: "cycles"`) — so numbers are only comparable within the same replica.

## What is unchanged

Non-verbose output and behavior are untouched; only the `--verbose` code paths changed, so existing bench snapshot tests are unaffected. The `dfx` warning is surfaced under `--verbose` only — `dfx` is deprecated and slated for removal, so I deliberately didn't grow its default output.

Made with [Cursor](https://cursor.com)