### PR TITLE
fix(cli): mops check --fix aborts on read-only files

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -99,7 +99,7 @@ mops check -- -Werror     # treat warnings as errors
 
 **Always use canister names, not file paths.** Per-canister args from `mops.toml` are applied automatically.
 
-`--fix` applies machine-applicable fixes from both moc and lintoko in one pass. Concurrent `--fix` runs (across processes) serialize automatically via an advisory lock at `.mops/fix.lock` — safe to invoke from multiple agents on the same project.
+`--fix` applies machine-applicable fixes from both moc and lintoko in one pass. Concurrent `--fix` runs (across processes) serialize automatically via an advisory lock at `.mops/fix.lock` — safe to invoke from multiple agents on the same project. Read-only files (e.g. frozen migrations) are skipped with a warning, not fixed.
 
 ### `mops build`
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- `mops check --fix` no longer aborts when a fixable file is read-only (e.g. a frozen migration chain file deliberately `chmod`'d to remove write access). The autofixer now skips such files with a warning and continues fixing the rest, instead of crashing the whole run on `EACCES`/`EPERM`.
+
 - `mops bench --verbose` is now actually verbose. It prints the benchmark pipeline up front — compiler version, replica + version, GC, profile, and whether the wasm is optimized (`dfx` post-optimizes with `optimize: "cycles"` via ic-wasm on deploy; `pocket-ic` runs the raw `moc` output) — logs the full `moc` build command, and streams the compiler and `dfx` output instead of capturing and discarding it. Notably this surfaces dfx's `WARNING: Failed to optimize the Wasm module`, which dfx prints (and then silently deploys the unoptimized module) when `optimize: "cycles"` fails — e.g. on multi-value modules that the bundled ic-wasm can't process. Previously all of this was hidden even with `--verbose`.
 
 ## 2.15.0

--- a/cli/helpers/autofix-motoko.ts
+++ b/cli/helpers/autofix-motoko.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { relative, resolve } from "node:path";
+import chalk from "chalk";
 import { execa } from "execa";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
@@ -186,6 +187,9 @@ export async function autofixMotoko(
   mocArgs: string[],
 ): Promise<AutofixResult | null> {
   const fixedFilesCodes = new Map<string, string[]>();
+  // Frozen migration files are often chmod'd read-only; warn once and skip
+  // them rather than aborting the whole run on EACCES/EPERM.
+  const readOnlySkipped = new Set<string>();
 
   for (let iteration = 0; iteration < MAX_FIX_ITERATIONS; iteration++) {
     const fixesByFile = new Map<string, DiagnosticFix[]>();
@@ -212,6 +216,10 @@ export async function autofixMotoko(
     let progress = false;
 
     for (const [file, fixes] of fixesByFile) {
+      if (readOnlySkipped.has(file)) {
+        continue;
+      }
+
       const original = await readFile(file, "utf-8");
       const { text: result, appliedCodes } = applyDiagnosticFixes(
         original,
@@ -222,7 +230,20 @@ export async function autofixMotoko(
         continue;
       }
 
-      await writeFile(file, result, "utf-8");
+      try {
+        await writeFile(file, result, "utf-8");
+      } catch (err: any) {
+        if (err?.code === "EACCES" || err?.code === "EPERM") {
+          readOnlySkipped.add(file);
+          console.warn(
+            chalk.yellow(
+              `Skipped read-only file ${relative(process.cwd(), file)} (${appliedCodes.length} fix(es) not applied)`,
+            ),
+          );
+          continue;
+        }
+        throw err;
+      }
       progress = true;
 
       const existing = fixedFilesCodes.get(file) ?? [];

--- a/cli/tests/check-fix.test.ts
+++ b/cli/tests/check-fix.test.ts
@@ -1,5 +1,11 @@
 import { beforeAll, describe, expect, test } from "@jest/globals";
-import { cpSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
+import {
+  chmodSync,
+  cpSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+} from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "path";
 import { lock } from "proper-lockfile";
@@ -22,7 +28,9 @@ describe("check --fix", () => {
 
   beforeAll(() => {
     for (const file of readdirSync(runDir).filter((f) => f.endsWith(".mo"))) {
-      unlinkSync(path.join(runDir, file));
+      const p = path.join(runDir, file);
+      chmodSync(p, 0o644);
+      unlinkSync(p);
     }
   });
 
@@ -130,6 +138,22 @@ describe("check --fix", () => {
 
     expect(fixResult.stdout).toContain("1 fix applied");
     expect(readFileSync(runFilePath, "utf-8")).not.toContain("<Nat>");
+  });
+
+  test("read-only file is skipped, not crashed", async () => {
+    const runFilePath = copyFixture("M0223.mo");
+    const before = readFileSync(runFilePath, "utf-8");
+    chmodSync(runFilePath, 0o444);
+
+    const result = await cli(
+      ["check", runFilePath, "--fix", "--", warningFlags],
+      { cwd: fixDir },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toMatch(/Skipped read-only file/);
+    // File left untouched since the fix couldn't be written.
+    expect(readFileSync(runFilePath, "utf-8")).toBe(before);
   });
 
   test("verbose", async () => {

--- a/docs/docs/cli/4-dev/04-mops-check.md
+++ b/docs/docs/cli/4-dev/04-mops-check.md
@@ -75,6 +75,8 @@ mops check --fix
 
 After applying fixes, `--fix` re-checks all files and runs stable compatibility checks (if configured). If type-checking fails after fixing, stable checks are skipped.
 
+Read-only files (e.g. frozen migration chain files `chmod`'d read-only) are skipped with a warning rather than aborting the run; the remaining files are still fixed.
+
 Concurrent `--fix` runs in the same project (e.g. two agents on the same checkout) serialize via an advisory lock at `.mops/fix.lock`. The second invocation prints `Waiting for another mops --fix run to finish...` and resumes once the first one releases. Plain `mops check` is read-only and never blocks.
 
 ### `--verbose`


### PR DESCRIPTION
`mops check --fix` aborted the entire run with an `EACCES`/`EPERM` exception when any file in the fix set was read-only — most commonly a frozen migration-chain file deliberately `chmod`'d to remove write access. `moc` still emits machine-applicable suggestions for those files, so the autofixer tried to write them back and threw before applying any fixes, including the ones it could have written to other files.

The autofixer now skips a file it can't write, warns, and continues fixing the rest. Skipped files are remembered so they aren't re-read, re-attempted, or re-warned across the fix loop's iterations; non-permission write errors still propagate.

Before — a read-only `migrations/001_Init.mo` in the fix set:

```
$ mops check --fix
Error: EACCES: permission denied, open '.../migrations/001_Init.mo'
    at async open (node:internal/fs/promises:...)
```

After:

```
$ mops check --fix
Skipped read-only file migrations/001_Init.mo (2 fix(es) not applied)

✓ 3 fixes applied to 2 files
```

Made with [Cursor](https://cursor.com)