### PR TITLE
perf(cli): load PocketIC client only when starting a replica

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Load the PocketIC client lazily, only when a command actually starts a replica. Commands like `mops check`, `mops build`, and `mops install` no longer pay to load it (and its `@icp-sdk/core` dependency) at startup. This also unblocks running the CLI via `tsx` in local dev, where `pic-js-mops` (shipped as ESM without `"type": "module"`) fails to resolve as a static import.
+
 - `mops bench --verbose` is now actually verbose. It prints the benchmark pipeline up front — compiler version, replica + version, GC, profile, and whether the wasm is optimized (`dfx` post-optimizes with `optimize: "cycles"` via ic-wasm on deploy; `pocket-ic` runs the raw `moc` output) — logs the full `moc` build command, and streams the compiler and `dfx` output instead of capturing and discarding it. Notably this surfaces dfx's `WARNING: Failed to optimize the Wasm module`, which dfx prints (and then silently deploys the unoptimized module) when `optimize: "cycles"` fails — e.g. on multi-value modules that the bundled ic-wasm can't process. Previously all of this was hidden even with `--verbose`.
 
 ## 2.15.0

--- a/cli/helpers/pocket-ic-client.ts
+++ b/cli/helpers/pocket-ic-client.ts
@@ -1,9 +1,9 @@
 import semver from "semver";
-import { PocketIc, PocketIcServer } from "pic-ic";
-import {
+import type { PocketIc, PocketIcServer } from "pic-ic";
+import type {
   PocketIc as PocketIcModern,
   PocketIcServer as PocketIcServerModern,
-  type StartServerOptions,
+  StartServerOptions,
 } from "pic-js-mops";
 import { readConfig } from "../mops.js";
 
@@ -20,13 +20,19 @@ function isLegacy(): boolean {
 export async function startPocketIc(
   options: StartServerOptions,
 ): Promise<{ server: AnyPocketIcServer; client: AnyPocketIc }> {
+  // Imported lazily so commands that never start a replica don't load the
+  // PocketIC client. `pic-js-mops` ships ESM without `type: module`, which a
+  // static import fails to resolve under tsx (local dev); a dynamic import
+  // resolves it on every platform.
   if (isLegacy()) {
+    const { PocketIc, PocketIcServer } = await import("pic-ic");
     let server = await PocketIcServer.start(options);
     let client = await PocketIc.create(server.getUrl());
     return { server, client };
   }
 
-  let server = await PocketIcServerModern.start(options);
-  let client = await PocketIcModern.create(server.getUrl());
+  const { PocketIc, PocketIcServer } = await import("pic-js-mops");
+  let server = await PocketIcServer.start(options);
+  let client = await PocketIc.create(server.getUrl());
   return { server, client };
 }


### PR DESCRIPTION
Every `mops` invocation eagerly loaded the PocketIC client (`pic-js-mops` / `pic-ic`) and its `@icp-sdk/core` dependency at startup, even for commands that never touch a replica — `mops check`, `mops build`, `mops install`, etc. The two clients are now imported dynamically inside `startPocketIc`, so only `mops test`/`bench`/replica flows pay for them.

This also fixes a hard CLI boot failure in local dev. `pic-js-mops@0.14.8` ships its `dist` as ESM (`export *`) but its `package.json` declares no `"type": "module"`, so under `tsx` (how the CLI runs in dev, e.g. via `npm run mops` and the Jest suite) the package is classified as CommonJS and a *static* named import can't be linked:

Before — any command crashed at boot:

```
$ npm run mops -- --version
SyntaxError: The requested module 'pic-js-mops' does not provide an export named 'PocketIc'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job)
```

After:

```
$ npm run mops -- --version
CLI 2.15.0
API 1.3
```

A dynamic `import()` resolves the named exports correctly regardless of the package's classification, so the fix holds on every platform without touching the dependency. The whole `cli` Jest suite — which spawns the CLI via `tsx` — now boots and runs locally again (it previously failed to start before any test logic ran).

## Follow-up worth flagging
The underlying cause is `pic-js-mops` being mispackaged (ESM payload without `"type": "module"`). Since DFINITY now maintains `pic-js` / `@dfinity/pic`, the durable fix is to get that flag added upstream and republished; tracked separately. Note `@dfinity/pic` is not a drop-in replacement here — it dropped the `binPath`/`ttl`/public `serverProcess` API that mops relies on to drive its toolchain-managed PocketIC binary, which is why the fork exists.

Made with [Cursor](https://cursor.com)