### PR TITLE
release: CLI v2.15.1

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 2.15.1
+
 - `mops check --fix` no longer aborts when a fixable file is read-only (e.g. a frozen migration chain file deliberately `chmod`'d to remove write access). The autofixer now skips such files with a warning and continues fixing the rest, instead of crashing the whole run on `EACCES`/`EPERM`.
 
 - Load the PocketIC client lazily, only when a command actually starts a replica. Commands like `mops check`, `mops build`, and `mops install` no longer pay to load it (and its `@icp-sdk/core` dependency) at startup. This also unblocks running the CLI via `tsx` in local dev, where `pic-js-mops` (shipped as ESM without `"type": "module"`) fails to resolve as a static import.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ic-mops",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ic-mops",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "license": "MIT",
       "dependencies": {
         "@icp-sdk/core": "4.0.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-mops",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "type": "module",
   "bin": {
     "mops": "dist/bin/mops.js",


### PR DESCRIPTION
Release CLI v2.15.1.

Made with [Cursor](https://cursor.com)