### PR TITLE
release: CLI v2.15.2

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 2.15.2
+
 - `mops check-stable` (and the stable check inside `mops check`) reports when `[canisters.<name>.migrations].check-limit` is set but more migrations are pending than the limit allows. If the compatibility check failed, the check-limit diagnostic replaces the misleading `moc` error; if it passed anyway, a warning is shown. Compares the deployed `.most` baseline against the local chain; use `--no-check-limit` to suppress.
 
 ## 2.15.1

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ic-mops",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ic-mops",
-      "version": "2.15.1",
+      "version": "2.15.2",
       "license": "MIT",
       "dependencies": {
         "@icp-sdk/core": "4.0.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-mops",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "type": "module",
   "bin": {
     "mops": "dist/bin/mops.js",


### PR DESCRIPTION
`mops check-stable` now reports when `check-limit` is set but too many migrations are pending, giving a clear diagnostic instead of a misleading `moc` error. Passes `--no-check-limit` to suppress.

Made with [Cursor](https://cursor.com)