### PR TITLE
fix(tests): scope migration-self-contained lint example to flat migrations/*.mo

### DIFF
--- a/cli/tests/lint-extra-example-rules/lint/migration-self-contained/migration-self-contained.toml
+++ b/cli/tests/lint-extra-example-rules/lint/migration-self-contained/migration-self-contained.toml
@@ -1,6 +1,6 @@
 name = "migration-self-contained"
 description = "Migration files must not import local modules (relative paths). Got: @path"
-includes = ["**/migrations/**"]
+includes = ["migrations/*.mo"]
 query = '''
 (import (text_literal) @path @error
   (#match? @path "^\"[^:]*\"$"))

--- a/cli/tests/lint-extra-example-rules/mops.toml
+++ b/cli/tests/lint-extra-example-rules/mops.toml
@@ -5,4 +5,4 @@ lintoko = "0.7.0"
 "src/Main.mo" = ["lint/no-types"]
 "src/Types.mo" = ["lint/types-only"]
 "src/Migration.mo" = ["lint/migration-only"]
-"migrations/**" = ["lint/migration-self-contained"]
+"migrations/*.mo" = ["lint/migration-self-contained"]


### PR DESCRIPTION
Follow-up to [#594](https://github.com/caffeinelabs/mops/pull/594).

The `migration-self-contained` example rule used `**/migrations/**` for both lintoko `includes` and `[lint.extra]`, which could match any `migrations` directory anywhere in the tree and recurse into subfolders. Projects using enhanced migrations keep a flat `migrations/*.mo` chain (as configured via `chain = "migrations"` in `mops.toml`), so the example should mirror that layout.

**Before**

```toml
# migration-self-contained.toml
includes = ["**/migrations/**"]

# mops.toml
[lint.extra]
"migrations/**" = ["lint/migration-self-contained"]
```

**After**

```toml
# migration-self-contained.toml
includes = ["migrations/*.mo"]

# mops.toml
[lint.extra]
"migrations/*.mo" = ["lint/migration-self-contained"]
```

If your chain path differs (e.g. `backend/migrations`), set both `includes` and `[lint.extra]` to that path with `/*.mo`.

## What is unchanged

No CLI behavior change — only the `lint-extra-example-rules` test fixture. No CHANGELOG entry.

Made with [Cursor](https://cursor.com)