### PR TITLE
feat(bench): EOP by default + --query for query-context measurement

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- `mops bench` now compiles benchmark canisters under **enhanced orthogonal persistence** (moc's default) instead of forcing `--legacy-persistence` — measuring the persistence mode real canisters run.
+- `mops bench --query` measures each cell in a **query** call instead of an update call. Queries run no GC on the IC, so the instruction counts exclude GC work an update would incur — for benchmarking `query`/read-only workloads realistically. Only for synchronous benchmark runners (no inter-canister `await`).
 - `[requirements].lintoko` declares a minimum lintoko version for package consumers. `mops install` (and `mops add`, `mops toolchain use`) warn when the project's lintoko is below a dependency's requirement, same as `moc` (#597).
 
 ## 2.15.2

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- `mops bench` now compiles benchmark canisters under **enhanced orthogonal persistence** (moc's default) instead of forcing `--legacy-persistence` — measuring the persistence mode real canisters run.
+- `mops bench` now compiles benchmark canisters under **enhanced orthogonal persistence** (moc's default) instead of forcing `--legacy-persistence` — measuring the persistence mode real canisters run. Pass `--legacy-persistence` to opt back into legacy persistence.
 - `mops bench --query` measures each cell in a **query** call instead of an update call. Queries run no GC on the IC, so the instruction counts exclude GC work an update would incur — for benchmarking `query`/read-only workloads realistically. Only for synchronous benchmark runners (no inter-canister `await`).
 - `[requirements].lintoko` declares a minimum lintoko version for package consumers. `mops install` (and `mops add`, `mops toolchain use`) warn when the project's lintoko is below a dependency's requirement, same as `moc` (#597).
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -566,6 +566,12 @@ program
   )
   .addOption(
     new Option(
+      "--legacy-persistence",
+      "Compile benchmark canisters under legacy persistence instead of enhanced orthogonal persistence (the default)",
+    ),
+  )
+  .addOption(
+    new Option(
       "--verbose",
       "Print the benchmark pipeline (compiler, replica, GC, optimization) and stream compiler/replica output, including dfx optimization warnings",
     ),

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -560,6 +560,12 @@ program
   // .addOption(new Option('--force-gc', 'Force GC'))
   .addOption(
     new Option(
+      "--query",
+      "Measure each cell in a query call (how `query` methods run on the IC: no GC). Only for benchmarks whose runner is synchronous (no inter-canister calls)",
+    ),
+  )
+  .addOption(
+    new Option(
       "--verbose",
       "Print the benchmark pipeline (compiler, replica, GC, optimization) and stream compiler/replica output, including dfx optimization warnings",
     ),

--- a/cli/commands/bench.ts
+++ b/cli/commands/bench.ts
@@ -40,6 +40,7 @@ type BenchOptions = {
   compilerVersion: string;
   gc: "copying" | "compacting" | "generational" | "incremental";
   forceGc: boolean;
+  query: boolean;
   save: boolean;
   compare: boolean;
   verbose: boolean;
@@ -61,6 +62,7 @@ export async function bench(
     compilerVersion: getMocVersion(true),
     gc: "copying",
     forceGc: true,
+    query: false,
     save: false,
     compare: false,
     verbose: false,
@@ -120,6 +122,10 @@ export async function bench(
         `  gc:        ${options.gc}${options.forceGc ? " (forced)" : ""}`,
       ),
     );
+    console.log(
+      chalk.gray(`  context:   ${options.query ? "query" : "update"}`),
+    );
+    console.log(chalk.gray(`  persistence: enhanced`));
     console.log(chalk.gray(`  profile:   ${options.profile}`));
     console.log(chalk.gray(`  optimize:  ${optimize}`));
   }
@@ -270,12 +276,9 @@ function computeDiffAll(
 function getMocArgs(options: BenchOptions): string {
   let args = "";
 
-  if (
-    options.compilerVersion &&
-    new SemVer(options.compilerVersion).compare("0.15.0") >= 0
-  ) {
-    args += " --legacy-persistence";
-  }
+  // Benchmarks compile under enhanced orthogonal persistence (moc's default
+  // since 0.15) — the mode real canisters run. We intentionally do NOT pass
+  // `--legacy-persistence`.
 
   if (options.forceGc) {
     args += " --force-gc";
@@ -533,13 +536,14 @@ async function runBenchFile(
     log();
   }
 
-  // run all cells
+  // run all cells. `--query` measures in query context (how `query` methods
+  // actually run on the IC: no GC), at the cost of not supporting benches whose
+  // runner performs async calls. Otherwise use the update path.
   for (let [rowIndex, row] of schema.rows.entries()) {
     for (let [colIndex, col] of schema.cols.entries()) {
-      let res = await actor.runCellUpdateAwait(
-        BigInt(rowIndex),
-        BigInt(colIndex),
-      );
+      let res = options.query
+        ? await actor.runCellQuery(BigInt(rowIndex), BigInt(colIndex))
+        : await actor.runCellUpdateAwait(BigInt(rowIndex), BigInt(colIndex));
       results.set(`${row}:${col}`, res);
 
       // @ts-ignore

--- a/cli/commands/bench.ts
+++ b/cli/commands/bench.ts
@@ -41,6 +41,7 @@ type BenchOptions = {
   gc: "copying" | "compacting" | "generational" | "incremental";
   forceGc: boolean;
   query: boolean;
+  legacyPersistence: boolean;
   save: boolean;
   compare: boolean;
   verbose: boolean;
@@ -63,6 +64,7 @@ export async function bench(
     gc: "copying",
     forceGc: true,
     query: false,
+    legacyPersistence: false,
     save: false,
     compare: false,
     verbose: false,
@@ -125,7 +127,11 @@ export async function bench(
     console.log(
       chalk.gray(`  context:   ${options.query ? "query" : "update"}`),
     );
-    console.log(chalk.gray(`  persistence: enhanced`));
+    console.log(
+      chalk.gray(
+        `  persistence: ${options.legacyPersistence ? "legacy" : "enhanced"}`,
+      ),
+    );
     console.log(chalk.gray(`  profile:   ${options.profile}`));
     console.log(chalk.gray(`  optimize:  ${optimize}`));
   }
@@ -277,8 +283,16 @@ function getMocArgs(options: BenchOptions): string {
   let args = "";
 
   // Benchmarks compile under enhanced orthogonal persistence (moc's default
-  // since 0.15) — the mode real canisters run. We intentionally do NOT pass
-  // `--legacy-persistence`.
+  // since 0.15) — the mode real canisters run. Pass `--legacy-persistence`
+  // only when the user opts in, and only where moc supports the flag (>= 0.15;
+  // legacy is already the default below it).
+  if (
+    options.legacyPersistence &&
+    options.compilerVersion &&
+    new SemVer(options.compilerVersion).compare("0.15.0") >= 0
+  ) {
+    args += " --legacy-persistence";
+  }
 
   if (options.forceGc) {
     args += " --force-gc";

--- a/docs/docs/cli/4-dev/02-mops-bench.md
+++ b/docs/docs/cli/4-dev/02-mops-bench.md
@@ -77,6 +77,12 @@ This reflects how `query` methods actually execute on the IC: queries run no gar
 
 Only works for benchmarks whose runner is **synchronous** — a runner that performs inter-canister (`await`) calls needs the update path and must be run without `--query`.
 
+### `--legacy-persistence`
+
+Compile benchmark canisters under legacy persistence instead of enhanced orthogonal persistence (the default).
+
+Use it to measure a canister that still uses legacy persistence. Has no effect with `moc < 0.15`, where legacy persistence is already the default.
+
 ### `--verbose`
 
 Print the benchmark pipeline up front — compiler version, replica + version, GC, profile, and whether the wasm is optimized — then log the full `moc` build command and stream the compiler and `dfx` output (including any deploy/optimization warnings) instead of hiding it.

--- a/docs/docs/cli/4-dev/02-mops-bench.md
+++ b/docs/docs/cli/4-dev/02-mops-bench.md
@@ -22,8 +22,8 @@ The output format is a markdown table, so you can copy-paste it into your `READM
 Under the hood, Mops will:
 - Start a local replica on port `4944`
 - Wrap each `*.bench.mo` file in a canister
-- Compile canisters with `--force-gc` flag and deploy them
-- Run each cell of the benchmark file as an update call
+- Compile canisters under enhanced orthogonal persistence (moc's default) with the `--force-gc` flag and deploy them
+- Run each cell of the benchmark file as an update call (or a query call with [`--query`](#--query))
 - For each call measure usage of wasm instructions(`performance_counter`) and heap size(`rts_heap_size`)
 
 :::caution Instruction counts depend on the replica
@@ -68,6 +68,14 @@ Save benchmark results to `.bench/<filename>.json` file.
 ### `--compare`
 
 Compare benchmark results with the results from `.bench/<filename>.json` file.
+
+### `--query`
+
+Measure each cell in a **query** call instead of an update call.
+
+This reflects how `query` methods actually execute on the IC: queries run no garbage collection, so the instruction counts exclude GC work that an update would incur. Use it to benchmark read-only/`query` workloads realistically.
+
+Only works for benchmarks whose runner is **synchronous** — a runner that performs inter-canister (`await`) calls needs the update path and must be run without `--query`.
 
 ### `--verbose`
 


### PR DESCRIPTION
`mops bench` compiled benchmark canisters with `--legacy-persistence` and ran every cell as an **update** call — neither reflects how a real `query` canister executes on the IC. This makes the instruction counts unrepresentative for read-only/`query` workloads (they include GC work a query never does, under the wrong persistence mode).

## Changes
- **EOP by default** — `getMocArgs` no longer forces `--legacy-persistence` (it was gated only on `moc ≥ 0.15`). The bench canister is already a `persistent actor`, so dropping the flag compiles it under enhanced orthogonal persistence — moc's default and the mode real canisters run.
- **`--query`** — measures each cell via the canister's existing `runCellQuery` (a `query` method) instead of `runCellUpdateAwait`. Queries run **no GC** on the IC, so the counts exclude GC work an update would incur. Synchronous runners only (async/inter-canister runners still need the update path).
- Verbose pipeline now prints `context` (query/update) and `persistence`.

No change to the `mops-bench` library — the canister template already exposes `runCellQuery`.

## Validation
- `npm run check` (tsc) passes.
- Smoke-tested via `tsx` against a real project: verbose prints `context: query` / `persistence: enhanced` / `gc: incremental`, and the measured numbers shift as expected — the real-`runWith` floor drops sharply (no GC counted) while raw allocation rises slightly under 64-bit EOP.

## Docs / changelog
- `docs/docs/cli/4-dev/02-mops-bench.md`: updated "How it works" + new `### --query` section.
- `cli/CHANGELOG.md`: entries under `## Next`.
- `--help` carries a description for `--query`.
- The `mops-cli` skill documents no individual bench flags, so nothing there to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)