### PR TITLE
fix: drop `-S preview2=n` from wasmtime args in `mops test`

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- `mops test` no longer passes `-S preview2=n` to wasmtime. The flag was deprecated in wasmtime 46 (printing a warning to stderr that was misread as a test failure) and became a hard error in wasmtime 47.0.0 (2026-07-20). moc emits WASI-preview1 modules, which wasmtime runs correctly without the flag.
+
 ## 2.16.1
 
 - Fix `mops bench` crashing on moc 0.15+ with the default `--gc copying`: `--copying-gc` is rejected under enhanced orthogonal persistence, which became the default persistence mode in 2.16.0. The default GC is now `incremental` (moc's default and the only collector available under EOP). Selecting a legacy collector (`copying`, `compacting`, `generational`) now implies `--legacy-persistence`, since moc only accepts them there.

--- a/cli/commands/test/test.ts
+++ b/cli/commands/test/test.ts
@@ -366,8 +366,6 @@ export async function testWithReporter(
               config.toolchain?.wasmtime >= "14.0.0"
             ) {
               wasmtimeArgs = [
-                "-S",
-                "preview2=n",
                 "-C",
                 "cache=n",
                 "-W",


### PR DESCRIPTION
`-S preview2=n` was deprecated in wasmtime 46 — every invocation printed a deprecation warning to stderr, which `mops test` treated as a test failure (all tests reported ✖ FAIL with the warning text as the message). Wasmtime 47.0.0, released 2026-07-20, made it a hard error, breaking `mops test` entirely for anyone pinned to wasmtime ≥ 47.

The flag is unnecessary: moc emits WASI-preview1 modules, which wasmtime runs correctly without it.

**Before** (wasmtime 46+):
```
✖ test/sha2.test.mo
 ✖ FAIL WARNING: the `-Spreview2=n` flag will be a hard error in Wasmtime 47.0.0 on 2026-07-20. ...
```

**After**: tests run and report correctly.

Closes #611.

Made with [Cursor](https://cursor.com)