### PR TITLE
fix(bench): use proper arg array when invoking moc

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fix `mops bench` accepting a `[moc] args` entry with an embedded space (e.g. `["-E=M0154 --legacy-persistence"]`) when it should reject it. `mops bench` now invokes `moc` with a proper argument array (same as `mops test`), so a mis-formatted entry produces the same error: `moc: invalid warning code: M0154 --legacy-persistence`.
+
 ## 2.16.1
 
 - Fix `mops bench` crashing on moc 0.15+ with the default `--gc copying`: `--copying-gc` is rejected under enhanced orthogonal persistence, which became the default persistence mode in 2.16.0. The default GC is now `incremental` (moc's default and the only collector available under EOP). Selecting a legacy collector (`copying`, `compacting`, `generational`) now implies `--legacy-persistence`, since moc only accepts them there.

--- a/cli/commands/bench.ts
+++ b/cli/commands/bench.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { globSync } from "glob";
 import { markdownTable } from "markdown-table";
 import { createLogUpdate } from "log-update";
-import { execaCommand } from "execa";
+import { execa } from "execa";
 import stringWidth from "string-width";
 import { filesize } from "filesize";
 import terminalSize from "terminal-size";
@@ -24,7 +24,7 @@ import { getMocVersion } from "../helpers/get-moc-version.js";
 import { getDfxVersion } from "../helpers/get-dfx-version.js";
 import { warnIfDfxReplica } from "../helpers/deprecate-dfx-replica.js";
 import { getMocPath } from "../helpers/get-moc-path.js";
-import { sources } from "./sources.js";
+import { sourcesArgs } from "./sources.js";
 import { MOTOKO_GLOB_CONFIG } from "../constants.js";
 
 import { Benchmark, Benchmarks } from "../declarations/main/main.did.js";
@@ -294,35 +294,35 @@ function isLegacyGc(gc: BenchOptions["gc"]): boolean {
   return gc === "copying" || gc === "compacting" || gc === "generational";
 }
 
-function getMocArgs(options: BenchOptions): string {
-  let args = "";
+function getMocArgs(options: BenchOptions): string[] {
+  const args: string[] = [];
 
-  let mocAtLeast015 =
+  const mocAtLeast015 =
     !!options.compilerVersion &&
     new SemVer(options.compilerVersion).compare("0.15.0") >= 0;
 
   // Legacy collectors require legacy persistence; moc < 0.15 is already legacy
   // and has no --legacy-persistence flag.
-  let useLegacyPersistence =
+  const useLegacyPersistence =
     options.legacyPersistence || isLegacyGc(options.gc);
 
   if (useLegacyPersistence && mocAtLeast015) {
-    args += " --legacy-persistence";
+    args.push("--legacy-persistence");
   }
 
   if (options.forceGc) {
-    args += " --force-gc";
+    args.push("--force-gc");
   }
 
   // Under EOP the GC is fixed; only pass a collector flag where it's selectable.
   if (options.gc && (useLegacyPersistence || !mocAtLeast015)) {
-    args += ` --${options.gc}-gc`;
+    args.push(`--${options.gc}-gc`);
   }
 
   if (options.profile === "Debug") {
-    args += " --debug";
+    args.push("--debug");
   } else if (options.profile === "Release") {
-    args += " --release";
+    args.push("--release");
   }
 
   return args;
@@ -357,13 +357,22 @@ async function deployBenchFile(
 
   // build canister
   let mocPath = getMocPath();
-  let mocArgs = getMocArgs(options);
-  let buildCmd = `${mocPath} -c --idl canister.mo ${globalMocArgs.join(" ")} ${mocArgs} ${(await sources({ cwd: tempDir })).join(" ")}`;
+  let mocArgsList = getMocArgs(options);
+  let buildArgs = [
+    "-c",
+    "--idl",
+    "canister.mo",
+    ...(await sourcesArgs({ cwd: tempDir })).flat(),
+    ...globalMocArgs,
+    ...mocArgsList,
+  ];
   if (options.verbose) {
-    console.log(chalk.gray(`[${canisterName}] ${buildCmd}`));
+    console.log(
+      chalk.gray(`[${canisterName}] ${mocPath} ${buildArgs.join(" ")}`),
+    );
     console.time(`build ${canisterName}`);
   }
-  await execaCommand(buildCmd, {
+  await execa(mocPath, buildArgs, {
     cwd: tempDir,
     // `inherit` so the compiler output (warnings/errors) is streamed under --verbose
     stdio: options.verbose ? "inherit" : ["pipe", "ignore", "pipe"],

--- a/cli/tests/bench.test.ts
+++ b/cli/tests/bench.test.ts
@@ -19,4 +19,15 @@ describe("bench", () => {
       rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
     }
   });
+
+  test("rejects moc args with embedded spaces (single array entry with space)", async () => {
+    const cwd = path.join(import.meta.dirname, "bench/moc-args-invalid");
+    try {
+      const result = await cli(["bench"], { cwd });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toMatch(/invalid warning code/);
+    } finally {
+      rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+    }
+  });
 });

--- a/cli/tests/bench/moc-args-invalid/bench/simple.bench.mo
+++ b/cli/tests/bench/moc-args-invalid/bench/simple.bench.mo
@@ -1,0 +1,25 @@
+module {
+  type Schema = {
+    name : Text;
+    description : Text;
+    rows : [Text];
+    cols : [Text];
+  };
+
+  class Bench(schema : Schema, run : (Nat, Nat) -> ()) {
+    public func getVersion() : Nat = 1;
+    public func getSchema() : Schema = schema;
+    public let runCell = run;
+  };
+
+  public func init() : Bench {
+    let schema : Schema = {
+      name = "Simple";
+      description = "";
+      rows = ["a"];
+      cols = ["1"];
+    };
+    func run(_ri : Nat, _ci : Nat) {};
+    Bench(schema, run);
+  };
+};

--- a/cli/tests/bench/moc-args-invalid/mops.toml
+++ b/cli/tests/bench/moc-args-invalid/mops.toml
@@ -1,0 +1,11 @@
+[dependencies]
+core = "2.0.0"
+
+[toolchain]
+moc = "1.3.0"
+pocket-ic = "12.0.0"
+
+[moc]
+# Intentionally invalid: two args smashed into one string with an embedded space.
+# mops bench must reject this (same as mops test does).
+args = ["-E=M0154 --legacy-persistence"]


### PR DESCRIPTION
`mops bench` was silently accepting a `[moc]` args entry with an embedded space — e.g. `["-E=M0154 --legacy-persistence"]` — when it should error. `mops test` correctly rejects this because it passes the args array to `spawn()` directly (each element = one argument). `mops bench` used `execaCommand(buildCmd, …)` with a shell-string where `globalMocArgs.join(" ")` would let the shell parser re-split on whitespace, masking the malformed entry.

**Root cause**: shell-string construction silently re-split multi-word entries; proper argument arrays pass each element as one token so moc sees `"-E=M0154 --legacy-persistence"` as a single (invalid) argument and errors with:

```
moc: invalid warning code: M0154 --legacy-persistence. Run 'moc --warn-help' to see available warning codes.
```

**Fix**: replace `execaCommand(string)` with `execa(file, args[])` in `deployBenchFile` (same pattern as `mops test`, `mops check`, `mops check-stable`). `getMocArgs` is also changed to return `string[]` for consistency. Package source flags now use `sourcesArgs().flat()` (individual arguments) instead of `sources().join(" ")` (space-joined strings), which was also unsound under the array-based invocation.

Closes #613

Made with [Cursor](https://cursor.com)