### PR TITLE
feat: `mops test` and `mops bench` now support `-- <moc flags>` passthrough

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -59,11 +59,11 @@ Optional canister fields: `candid` (path to .did for compatibility checking), `i
 
 Flags are applied in this order (later overrides earlier):
 
-1. `[moc].args` — global, all commands (check, build, test, etc.)
+1. `[moc].args` — global, all commands (check, build, test, bench, etc.)
 2. `[build].args` — build only (e.g. `--release`)
 3. `[canisters.<name>.migrations]` — auto-injected `--enhanced-migration` (managed by mops)
 4. `[canisters.<name>].args` — per-canister
-5. CLI `-- <flags>` — one-off overrides
+5. CLI `-- <flags>` — one-off overrides; supported by `mops check`, `mops build`, `mops check-stable`, `mops generate`, `mops migrate`, `mops test`, and `mops bench`
 
 ## Core Commands
 
@@ -191,9 +191,23 @@ mops test my-test                 # filter by name
 mops test --mode wasi             # use wasmtime (for to_candid/from_candid)
 mops test --reporter verbose      # show Debug.print output
 mops test --watch                 # re-run on file changes
+mops test -- -Werror              # pass extra moc flags
 ```
 
 Replica tests (actor files or `// @testmode replica`) use `pocket-ic` from `[toolchain]`. With no pin they fall back to the deprecated `dfx` replica (warning printed) — pin `pocket-ic` in `[toolchain]` to silence it. Same applies to `mops bench` and `mops watch`.
+
+### `mops bench`
+
+Benchmarks live in `bench/*.bench.mo`:
+
+```bash
+mops bench                        # run all benchmarks
+mops bench my-bench               # filter by name
+mops bench --gc incremental       # select GC
+mops bench --save                 # save results to .bench/<name>.json
+mops bench --compare              # compare with saved results
+mops bench -- -Werror             # pass extra moc flags
+```
 
 ### `mops lint`
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `mops test` no longer passes `-S preview2=n` to wasmtime. The flag was deprecated in wasmtime 46 (printing a warning to stderr that was misread as a test failure) and became a hard error in wasmtime 47.0.0 (2026-07-20). moc emits WASI-preview1 modules, which wasmtime runs correctly without the flag.
 - Fix `mops bench` accepting a `[moc] args` entry with an embedded space (e.g. `["-E=M0154 --legacy-persistence"]`) when it should reject it. `mops bench` now invokes `moc` with a proper argument array (same as `mops test`), so a mis-formatted entry produces the same error: `moc: invalid warning code: M0154 --legacy-persistence`.
+- `mops test` and `mops bench` now support `-- <moc flags>` to pass extra flags directly to the Motoko compiler for that invocation (e.g. `mops test -- -Werror`), consistent with `mops build`, `mops check`, `mops check-stable`, `mops generate`, and `mops migrate`.
 
 ## 2.16.1
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -500,7 +500,7 @@ program.addCommand(deployedCommand);
 
 // test
 program
-  .command("test [filter]")
+  .command("test [filter...]")
   .description("Run tests")
   .addOption(
     new Option("-r, --reporter <reporter>", "Test reporter").choices([
@@ -528,9 +528,10 @@ program
     "\nArguments after -- are forwarded directly to moc, e.g.:\n  $ mops test -- -Werror",
   )
   .allowUnknownOption(true)
-  .action(async (filter, options) => {
+  .action(async (filterArr, options) => {
     checkConfigFile(true);
-    const { extraArgs } = parseExtraArgs();
+    const { extraArgs, args } = parseExtraArgs(filterArr);
+    const filter = args[0] ?? "";
     await installAll({
       silent: true,
       lock: "ignore",
@@ -541,7 +542,7 @@ program
 
 // bench
 program
-  .command("bench [filter]")
+  .command("bench [filter...]")
   .description("Run benchmarks")
   .addOption(
     new Option(
@@ -590,9 +591,10 @@ program
     "\nArguments after -- are forwarded directly to moc, e.g.:\n  $ mops bench -- -Werror",
   )
   .allowUnknownOption(true)
-  .action(async (filter, options) => {
+  .action(async (filterArr, options) => {
     checkConfigFile(true);
-    const { extraArgs } = parseExtraArgs();
+    const { extraArgs, args } = parseExtraArgs(filterArr);
+    const filter = args[0] ?? "";
     await installAll({
       silent: true,
       lock: "ignore",

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -523,14 +523,20 @@ program
   )
   .option("-w, --watch", "Enable watch mode")
   .option("--verbose", "Verbose output")
+  .addHelpText(
+    "after",
+    "\nArguments after -- are forwarded directly to moc, e.g.:\n  $ mops test -- -Werror",
+  )
+  .allowUnknownOption(true)
   .action(async (filter, options) => {
     checkConfigFile(true);
+    const { extraArgs } = parseExtraArgs();
     await installAll({
       silent: true,
       lock: "ignore",
       installFromLockFile: true,
     });
-    await test(filter, options);
+    await test(filter, { ...options, extraArgs });
   });
 
 // bench
@@ -579,14 +585,20 @@ program
       "Print the benchmark pipeline (compiler, replica, GC, context, persistence, profile, optimization) and stream compiler/replica output, including dfx optimization warnings",
     ),
   )
+  .addHelpText(
+    "after",
+    "\nArguments after -- are forwarded directly to moc, e.g.:\n  $ mops bench -- -Werror",
+  )
+  .allowUnknownOption(true)
   .action(async (filter, options) => {
     checkConfigFile(true);
+    const { extraArgs } = parseExtraArgs();
     await installAll({
       silent: true,
       lock: "ignore",
       installFromLockFile: true,
     });
-    await bench(filter, options);
+    await bench(filter, { ...options, extraArgs });
   });
 
 // template

--- a/cli/commands/bench.ts
+++ b/cli/commands/bench.ts
@@ -47,6 +47,7 @@ type BenchOptions = {
   verbose: boolean;
   silent: boolean;
   profile: "Debug" | "Release";
+  extraArgs: string[];
 };
 
 export async function bench(
@@ -70,6 +71,7 @@ export async function bench(
     verbose: false,
     silent: false,
     profile: dfxJson?.profile || "Release",
+    extraArgs: [],
   };
 
   let options: BenchOptions = { ...defaultOptions, ...optionsArg };
@@ -365,6 +367,7 @@ async function deployBenchFile(
     ...(await sourcesArgs({ cwd: tempDir })).flat(),
     ...globalMocArgs,
     ...mocArgsList,
+    ...(options.extraArgs ?? []),
   ];
   if (options.verbose) {
     console.log(

--- a/cli/commands/bench.ts
+++ b/cli/commands/bench.ts
@@ -367,7 +367,7 @@ async function deployBenchFile(
     ...(await sourcesArgs({ cwd: tempDir })).flat(),
     ...globalMocArgs,
     ...mocArgsList,
-    ...(options.extraArgs ?? []),
+    ...options.extraArgs,
   ];
   if (options.verbose) {
     console.log(

--- a/cli/commands/test/test.ts
+++ b/cli/commands/test/test.ts
@@ -44,6 +44,7 @@ type TestOptions = {
   mode: TestMode;
   replica: ReplicaName;
   verbose: boolean;
+  extraArgs: string[];
 };
 
 let replica = new Replica();
@@ -84,6 +85,8 @@ export async function test(filter = "", options: Partial<TestOptions> = {}) {
 
   replica.type = replicaType;
   replica.verbose = !!options.verbose;
+
+  let extraArgs = options.extraArgs ?? [];
 
   if (options.watch) {
     replica.ttl = 60 * 15; // 15 minutes
@@ -128,6 +131,7 @@ export async function test(filter = "", options: Partial<TestOptions> = {}) {
         true,
         controller.signal,
         explicitReplica,
+        extraArgs,
       );
       await curRun;
 
@@ -157,6 +161,7 @@ export async function test(filter = "", options: Partial<TestOptions> = {}) {
       false,
       undefined,
       explicitReplica,
+      extraArgs,
     );
     if (!passed) {
       process.exit(maxMocExit >= 2 ? 2 : 1);
@@ -182,6 +187,7 @@ async function runAll(
   watch = false,
   signal?: AbortSignal,
   explicitReplica = false,
+  extraArgs: string[] = [],
 ): Promise<boolean> {
   let done = await testWithReporter(
     reporterName,
@@ -191,6 +197,7 @@ async function runAll(
     watch,
     signal,
     explicitReplica,
+    extraArgs,
   );
   return done;
 }
@@ -203,6 +210,7 @@ export async function testWithReporter(
   watch = false,
   signal?: AbortSignal,
   explicitReplica = false,
+  extraArgs: string[] = [],
 ): Promise<boolean> {
   maxMocExit = 0;
   let rootDir = getRootDir();
@@ -322,6 +330,7 @@ export async function testWithReporter(
         "--error-detail=2",
         ...sourcesArr,
         ...globalMocArgs,
+        ...extraArgs,
         file,
       ].filter((x) => x);
 

--- a/docs/docs/cli/4-dev/01-mops-test.md
+++ b/docs/docs/cli/4-dev/01-mops-test.md
@@ -85,7 +85,13 @@ If you run `mops test --replica pocket-ic` AND `pocket-ic` is not specified in `
 
 Show replica logs
 
+### `-- <moc flags>`
 
+Pass extra flags directly to the Motoko compiler for this invocation. Appended after `[moc].args` from `mops.toml`.
+
+```
+mops test -- -Werror
+```
 
 ## Replica tests
 

--- a/docs/docs/cli/4-dev/02-mops-bench.md
+++ b/docs/docs/cli/4-dev/02-mops-bench.md
@@ -88,3 +88,11 @@ Use it to measure a canister that still uses legacy persistence. Has no effect w
 ### `--verbose`
 
 Print the benchmark pipeline up front — compiler version, replica + version, GC, context (query/update), persistence, profile, and whether the wasm is optimized — then log the full `moc` build command and stream the compiler and `dfx` output (including any deploy/optimization warnings) instead of hiding it.
+
+### `-- <moc flags>`
+
+Pass extra flags directly to the Motoko compiler for this invocation. Appended after `[moc].args` from `mops.toml`.
+
+```
+mops bench -- -Werror
+```


### PR DESCRIPTION
`mops test` and `mops bench` previously had no way to pass extra flags to `moc` at invocation time — the only option was `[moc].args` in `mops.toml`, which applies permanently and to all commands. Every other build-related command (`mops build`, `mops check`, `mops check-stable`, `mops generate`, `mops migrate`) already had the `-- <flags>` escape hatch.

Both commands now accept arguments after `--`, appended after `[moc].args` from `mops.toml`.

**Before / After**

```bash
# Before: no way to pass -Werror just for a test run
mops test

# After
mops test -- -Werror
mops bench -- -Werror
mops test -- --ai-errors
```

`--help` for both commands now shows the passthrough under the options list, docs pages updated, and the `mops-cli` skill updated.

Made with [Cursor](https://cursor.com)