### PR TITLE
fix(cli): recover stale mops.lock under CI and deprecate CI lock auto-detect

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -71,9 +71,13 @@ Flags are applied in this order (later overrides earlier):
 
 ```bash
 mops install
+mops install --lock update   # regenerate a stale/corrupt mops.lock
+mops install --lock check    # fail if lockfile is missing or stale (CI)
 ```
 
-Run after cloning or after manual `mops.toml` edits. Updates `mops.lock`. In CI, uses `--lock check` by default (fails if lockfile is stale).
+Run after cloning or after manual `mops.toml` edits. Updates `mops.lock` by default.
+
+When the `CI` env var is set and `--lock` is omitted, defaults to `--lock check` (deprecated — pass `--lock check` explicitly; auto-detection will be removed in v3). A stale lock fails with a hint to run `mops install --lock update`.
 
 ### `mops add <package>`
 
@@ -83,7 +87,7 @@ mops add core@2.5.0       # specific version
 mops add --dev test       # dev dependency
 ```
 
-Updates `mops.toml` and `mops.lock`.
+Updates `mops.toml` and `mops.lock` (even when `CI` is set).
 
 ### `mops check`
 

--- a/NEXT-MAJOR.md
+++ b/NEXT-MAJOR.md
@@ -26,7 +26,7 @@ Close the gap between update path and resolve path.
 
 ### Trust & lockfile model (move closer to npm/cargo)
 - Verify integrity at **download time**, stop re-hashing `.mops/` on every install; move on-disk verification behind `mops verify`. (GH #517)
-- Add `mops ci` (or `--frozen`): fail loudly on missing/out-of-date lock; drop the `CI` env-var auto-detection in `mops install`. (GH #516)
+- Add `mops ci` (or `--frozen`): fail loudly on missing/out-of-date lock; drop the `CI` env-var auto-detection in `mops install`. (GH #516). Deprecated with warnings in 2.x via `cli/helpers/deprecate-ci-lock.ts`.
 - `mops install` becomes purely additive (`npm install` semantics) — no implicit "switch to check mode".
 - `mops.lock` enabled by default (already done in 2.8); remove opt-in/legacy paths. (GH #288)
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fix `mops install` under `CI=1` aborting on a stale `mops.lock` with no recovery path (AGE-291). The deps-hash mismatch error now suggests `mops install --lock update`. `mops add` / `remove` / `update` / `sync` always default to updating the lockfile even when `CI` is set (they never supported `--lock check`). Using `CI` to auto-select `--lock check` on `mops install` is deprecated and warns; pass `--lock check` explicitly. Removal tracked in `NEXT-MAJOR.md` (GH #516).
+
 ## 2.17.0
 
 - `mops test` no longer passes `-S preview2=n` to wasmtime. The flag was deprecated in wasmtime 46 (printing a warning to stderr that was misread as a test failure) and became a hard error in wasmtime 47.0.0 (2026-07-20). moc emits WASI-preview1 modules, which wasmtime runs correctly without the flag.

--- a/cli/commands/add.ts
+++ b/cli/commands/add.ts
@@ -134,7 +134,10 @@ export async function add(
 
   let installedPackages = await syncLocalCache();
 
-  await Promise.all([notifyInstalls(installedPackages), checkIntegrity(lock)]);
+  await Promise.all([
+    notifyInstalls(installedPackages),
+    checkIntegrity(lock, { defaultLock: "update" }),
+  ]);
 
   logUpdate.clear();
 

--- a/cli/commands/remove.ts
+++ b/cli/commands/remove.ts
@@ -131,7 +131,7 @@ export async function remove(
   dryRun || writeConfig(config);
 
   await syncLocalCache();
-  await checkIntegrity(lock);
+  await checkIntegrity(lock, { defaultLock: "update" });
 
   console.log(chalk.green("Package removed ") + `${name} = "${version}"`);
 }

--- a/cli/commands/sync.ts
+++ b/cli/commands/sync.ts
@@ -42,7 +42,7 @@ export async function sync({ lock }: SyncOptions = {}) {
     await remove(pkg, { dev, lock: "ignore" });
   }
 
-  await checkIntegrity(lock);
+  await checkIntegrity(lock, { defaultLock: "update" });
 }
 
 async function getUsedPackages(): Promise<string[]> {

--- a/cli/commands/update.ts
+++ b/cli/commands/update.ts
@@ -106,5 +106,5 @@ export async function update(
     }
   }
 
-  await checkIntegrity(lock);
+  await checkIntegrity(lock, { defaultLock: "update" });
 }

--- a/cli/helpers/deprecate-ci-lock.ts
+++ b/cli/helpers/deprecate-ci-lock.ts
@@ -11,8 +11,8 @@ export function warnCiLockAutoDetect(): void {
   console.log(
     chalk.yellow(
       "Using the `CI` environment variable to default `--lock` to `check` is deprecated and will be removed in a future release.\n" +
-        "Pass `--lock check` explicitly (and commit `mops.lock`) to keep failing on a missing or stale lockfile.\n" +
-        "Note: explicit `--lock check` errors when the lock is missing; the deprecated CI auto-path skips a missing lock.",
+        "Pass `--lock check` explicitly (and commit `mops.lock`) to keep failing on a stale lockfile.\n" +
+        "Note: explicit `--lock check` also errors when the lock is missing; the deprecated CI auto-path skips a missing lock.",
     ),
   );
 }

--- a/cli/helpers/deprecate-ci-lock.ts
+++ b/cli/helpers/deprecate-ci-lock.ts
@@ -11,7 +11,8 @@ export function warnCiLockAutoDetect(): void {
   console.log(
     chalk.yellow(
       "Using the `CI` environment variable to default `--lock` to `check` is deprecated and will be removed in a future release.\n" +
-        "Pass `--lock check` (or a future `mops ci` / `--frozen` mode) explicitly to keep failing on a stale lockfile.",
+        "Pass `--lock check` explicitly (and commit `mops.lock`) to keep failing on a missing or stale lockfile.\n" +
+        "Note: explicit `--lock check` errors when the lock is missing; the deprecated CI auto-path skips a missing lock.",
     ),
   );
 }

--- a/cli/helpers/deprecate-ci-lock.ts
+++ b/cli/helpers/deprecate-ci-lock.ts
@@ -1,0 +1,17 @@
+import chalk from "chalk";
+
+let alreadyWarned = false;
+
+// Warn once when `CI` auto-selects `--lock check`. Removal tracked in NEXT-MAJOR.md (GH #516).
+export function warnCiLockAutoDetect(): void {
+  if (alreadyWarned) {
+    return;
+  }
+  alreadyWarned = true;
+  console.log(
+    chalk.yellow(
+      "Using the `CI` environment variable to default `--lock` to `check` is deprecated and will be removed in a future release.\n" +
+        "Pass `--lock check` (or a future `mops ci` / `--frozen` mode) explicitly to keep failing on a stale lockfile.",
+    ),
+  );
+}

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -235,7 +235,9 @@ export async function checkLockFile(force = false, regenerated = false) {
   // check if lock file exists
   if (!fs.existsSync(lockFile)) {
     if (force) {
-      console.error("Missing lock file. Run `mops install` to generate it.");
+      console.error(
+        "Missing lock file. Run `mops install --lock update` to generate it.",
+      );
       process.exit(1);
     }
     return;

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -154,7 +154,7 @@ export function readLockFile(): LockFile | null {
       return JSON.parse(fs.readFileSync(lockFile).toString()) as LockFile;
     } catch {
       console.error(
-        "mops.lock is corrupted. Delete it and run `mops install` to regenerate.",
+        "mops.lock is corrupted. Run `mops install --lock update` to regenerate it.",
       );
       process.exit(1);
     }
@@ -252,6 +252,7 @@ export async function checkLockFile(force = false, regenerated = false) {
     console.error(
       `Invalid lock file version: ${lockFileJsonGeneric.version}. Supported versions: ${supportedVersions.join(", ")}`,
     );
+    console.error("Run `mops install --lock update` to regenerate it.");
     process.exit(1);
   }
 
@@ -292,6 +293,7 @@ export async function checkLockFile(force = false, regenerated = false) {
         console.error(`Mismatched package ${name}`);
         console.error(`Locked: ${lockedDeps[name]}`);
         console.error(`Actual: ${resolvedDeps[name]}`);
+        console.error("Run `mops install --lock update` to regenerate it.");
         process.exit(1);
       }
     }
@@ -303,6 +305,7 @@ export async function checkLockFile(force = false, regenerated = false) {
     console.error(
       `Mismatched number of resolved packages: ${JSON.stringify(Object.keys(lockFileJson.hashes).length)} vs ${JSON.stringify(packageIds.length)}`,
     );
+    console.error("Run `mops install --lock update` to regenerate it.");
     process.exit(1);
   }
 
@@ -311,6 +314,7 @@ export async function checkLockFile(force = false, regenerated = false) {
     if (!(packageId in lockFileJson.hashes)) {
       console.error("Integrity check failed");
       console.error(`Missing package ${packageId} in lock file`);
+      console.error("Run `mops install --lock update` to regenerate it.");
       process.exit(1);
     }
   }
@@ -322,6 +326,7 @@ export async function checkLockFile(force = false, regenerated = false) {
       console.error(
         `Package ${packageId} in lock file but not in resolved packages`,
       );
+      console.error("Run `mops install --lock update` to regenerate it.");
       process.exit(1);
     }
 

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -37,7 +37,7 @@ type LockFile = LockFileV1 | LockFileV2 | LockFileV3;
 type CheckIntegrityOptions = {
   // When `--lock` is omitted, use this instead of the CI-aware default.
   // Mutating commands pass `"update"` so `CI` cannot force check after changing deps.
-  defaultLock?: "check" | "update";
+  defaultLock?: "update";
 };
 
 export async function checkIntegrity(
@@ -337,6 +337,7 @@ export async function checkLockFile(force = false, regenerated = false) {
         console.error(
           `File ${fileId} in lock file does not belong to package ${packageId}`,
         );
+        console.error("Run `mops install --lock update` to regenerate it.");
         process.exit(1);
       }
 

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -7,6 +7,7 @@ import { getDependencyType, getRootDir, readConfig } from "./mops.js";
 import { mainActor } from "./api/actors.js";
 import { resolvePackages } from "./resolve-packages.js";
 import { getPackageId } from "./helpers/get-package-id.js";
+import { warnCiLockAutoDetect } from "./helpers/deprecate-ci-lock.js";
 
 type LockFileGeneric = {
   version: number;
@@ -33,11 +34,28 @@ type LockFileV3 = {
 
 type LockFile = LockFileV1 | LockFileV2 | LockFileV3;
 
-export async function checkIntegrity(lock?: "check" | "update" | "ignore") {
+type CheckIntegrityOptions = {
+  // When `--lock` is omitted, use this instead of the CI-aware default.
+  // Mutating commands pass `"update"` so `CI` cannot force check after changing deps.
+  defaultLock?: "check" | "update";
+};
+
+export async function checkIntegrity(
+  lock?: "check" | "update" | "ignore",
+  { defaultLock }: CheckIntegrityOptions = {},
+) {
+  // Explicit `--lock` forces regeneration; omitted flag keeps the light skip path.
   let force = !!lock;
 
   if (!lock) {
-    lock = process.env["CI"] ? "check" : "update";
+    if (defaultLock) {
+      lock = defaultLock;
+    } else if (process.env["CI"]) {
+      warnCiLockAutoDetect();
+      lock = "check";
+    } else {
+      lock = "update";
+    }
   }
 
   if (lock === "update") {
@@ -246,6 +264,7 @@ export async function checkLockFile(force = false, regenerated = false) {
       console.error("Mismatched mops.toml hash");
       console.error(`Locked hash: ${lockFileJson.mopsTomlHash}`);
       console.error(`Actual hash: ${getMopsTomlHash()}`);
+      console.error("Run `mops install --lock update` to regenerate it.");
       process.exit(1);
     }
   }
@@ -257,6 +276,7 @@ export async function checkLockFile(force = false, regenerated = false) {
       console.error("Mismatched mops.toml dependencies hash");
       console.error(`Locked hash: ${lockFileJson.mopsTomlDepsHash}`);
       console.error(`Actual hash: ${getMopsTomlDepsHash()}`);
+      console.error("Run `mops install --lock update` to regenerate it.");
       process.exit(1);
     }
   }

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -203,6 +203,13 @@ describe("install", () => {
       expect(result.stdout + result.stderr).toMatch(
         /`CI` environment variable.*deprecated/,
       );
+
+      const recovered = await cli(["install", "--lock", "update"], {
+        cwd,
+        env: { CI: "1" },
+      });
+      expect(recovered.exitCode).toBe(0);
+      expect(readFileSync(lockFile, "utf8")).toMatch(/fuzz@1\.0\.0/);
     } finally {
       writeFileSync(tomlFile, originalToml);
       rmSync(lockFile, { force: true });
@@ -249,8 +256,41 @@ describe("install", () => {
       });
       expect(result.exitCode).toBe(0);
       expect(result.stderr).not.toMatch(/Integrity check failed/);
+      expect(result.stdout + result.stderr).not.toMatch(
+        /`CI` environment variable.*deprecated/,
+      );
       expect(readFileSync(tomlFile, "utf8")).toMatch(/fuzz/);
       expect(readFileSync(lockFile, "utf8")).toMatch(/fuzz@1\.0\.0/);
+    } finally {
+      writeFileSync(tomlFile, originalToml);
+      rmSync(lockFile, { force: true });
+      rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+    }
+  });
+
+  test("mops remove under CI updates the lockfile", async () => {
+    const cwd = path.join(import.meta.dirname, "install/success");
+    const lockFile = path.join(cwd, "mops.lock");
+    const tomlFile = path.join(cwd, "mops.toml");
+    const originalToml = readFileSync(tomlFile, "utf8");
+    rmSync(lockFile, { force: true });
+    try {
+      writeFileSync(
+        tomlFile,
+        '[dependencies]\ncore = "1.0.0"\nfuzz = "1.0.0"\n',
+      );
+      const first = await cli(["install"], { cwd, env: { CI: undefined } });
+      expect(first.exitCode).toBe(0);
+      expect(readFileSync(lockFile, "utf8")).toMatch(/fuzz@1\.0\.0/);
+
+      const result = await cli(["remove", "fuzz"], {
+        cwd,
+        env: { CI: "1" },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toMatch(/Integrity check failed/);
+      expect(readFileSync(tomlFile, "utf8")).not.toMatch(/fuzz/);
+      expect(readFileSync(lockFile, "utf8")).not.toMatch(/fuzz@1\.0\.0/);
     } finally {
       writeFileSync(tomlFile, originalToml);
       rmSync(lockFile, { force: true });

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -178,6 +178,86 @@ describe("install", () => {
     }
   });
 
+  // AGE-291: with CI set, install defaults to `--lock check` and used to abort
+  // on a stale deps hash with no recovery hint — a deadlock for agents that
+  // cannot `rm mops.lock`. Hint + deprecation warning for the CI auto-path.
+  test("CI install on a stale lock hints --lock update and warns about CI auto-detect", async () => {
+    const cwd = path.join(import.meta.dirname, "install/success");
+    const lockFile = path.join(cwd, "mops.lock");
+    const tomlFile = path.join(cwd, "mops.toml");
+    const originalToml = readFileSync(tomlFile, "utf8");
+    rmSync(lockFile, { force: true });
+    try {
+      const first = await cli(["install"], { cwd, env: { CI: undefined } });
+      expect(first.exitCode).toBe(0);
+
+      writeFileSync(
+        tomlFile,
+        '[dependencies]\ncore = "1.0.0"\nfuzz = "1.0.0"\n',
+      );
+
+      const result = await cli(["install"], { cwd, env: { CI: "1" } });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/Mismatched mops\.toml dependencies hash/);
+      expect(result.stderr).toMatch(/Run `mops install --lock update`/);
+      expect(result.stdout + result.stderr).toMatch(
+        /`CI` environment variable.*deprecated/,
+      );
+    } finally {
+      writeFileSync(tomlFile, originalToml);
+      rmSync(lockFile, { force: true });
+      rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+    }
+  });
+
+  test("CI install --lock check does not emit the CI auto-detect deprecation", async () => {
+    const cwd = path.join(import.meta.dirname, "install/success");
+    const lockFile = path.join(cwd, "mops.lock");
+    rmSync(lockFile, { force: true });
+    try {
+      const first = await cli(["install"], { cwd, env: { CI: undefined } });
+      expect(first.exitCode).toBe(0);
+
+      const result = await cli(["install", "--lock", "check"], {
+        cwd,
+        env: { CI: "1" },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).not.toMatch(
+        /`CI` environment variable.*deprecated/,
+      );
+    } finally {
+      rmSync(lockFile, { force: true });
+      rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+    }
+  });
+
+  // Mutating commands bypass CI→check so agents can add deps under CI=1.
+  test("mops add under CI updates the lockfile (does not abort on check)", async () => {
+    const cwd = path.join(import.meta.dirname, "install/success");
+    const lockFile = path.join(cwd, "mops.lock");
+    const tomlFile = path.join(cwd, "mops.toml");
+    const originalToml = readFileSync(tomlFile, "utf8");
+    rmSync(lockFile, { force: true });
+    try {
+      const first = await cli(["install"], { cwd, env: { CI: undefined } });
+      expect(first.exitCode).toBe(0);
+
+      const result = await cli(["add", "fuzz@1.0.0"], {
+        cwd,
+        env: { CI: "1" },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toMatch(/Integrity check failed/);
+      expect(readFileSync(tomlFile, "utf8")).toMatch(/fuzz/);
+      expect(readFileSync(lockFile, "utf8")).toMatch(/fuzz@1\.0\.0/);
+    } finally {
+      writeFileSync(tomlFile, originalToml);
+      rmSync(lockFile, { force: true });
+      rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+    }
+  });
+
   // Regression: parallel `mops install` runs against the same project used to
   // race in two places — global cache writes (`.mops/<pkg>` populated mid-write)
   // and local `.mops/<pkg>` copies — leaving zero-byte / partially-written

--- a/docs/docs/10-mops.lock.md
+++ b/docs/docs/10-mops.lock.md
@@ -46,9 +46,9 @@ _It's only faster when there are no globally cached packages — for example whe
 
 ## CI environments
 
-**Deprecated:** when the `CI` environment variable is set and `--lock` is omitted, `mops install` defaults to `--lock check` and prints a deprecation warning. This auto-detection will be removed in a future release — pass `--lock check` explicitly to keep that behavior.
+**Deprecated:** when the `CI` environment variable is set and `--lock` is omitted, `mops install` defaults to `--lock check` and prints a deprecation warning. This auto-detection will be removed in a future release — pass `--lock check` explicitly (and commit `mops.lock`) to keep that behavior.
 
-While it remains: if `mops.lock` does not exist, integrity checking is skipped and no lock file is created. To enforce the lock in CI, commit `mops.lock` and pass `--lock check` (or rely on the deprecated `CI` auto-path for now). If the lock is stale, regenerate with `mops install --lock update`.
+Note: explicit `--lock check` errors when the lock is missing; the deprecated CI auto-path skips a missing lock. If the lock is stale, regenerate with `mops install --lock update`.
 
 Dependency-mutating commands (`mops add`, `mops remove`, `mops update`, `mops sync`) always default to updating the lockfile, even when `CI` is set.
 

--- a/docs/docs/10-mops.lock.md
+++ b/docs/docs/10-mops.lock.md
@@ -46,7 +46,11 @@ _It's only faster when there are no globally cached packages — for example whe
 
 ## CI environments
 
-In CI, if `mops.lock` does not exist, integrity checking is skipped and no lock file is created. To enforce the lock in CI, commit `mops.lock` to your repository before running CI.
+**Deprecated:** when the `CI` environment variable is set and `--lock` is omitted, `mops install` defaults to `--lock check` and prints a deprecation warning. This auto-detection will be removed in a future release — pass `--lock check` explicitly to keep that behavior.
+
+While it remains: if `mops.lock` does not exist, integrity checking is skipped and no lock file is created. To enforce the lock in CI, commit `mops.lock` and pass `--lock check` (or rely on the deprecated `CI` auto-path for now). If the lock is stale, regenerate with `mops install --lock update`.
+
+Dependency-mutating commands (`mops add`, `mops remove`, `mops update`, `mops sync`) always default to updating the lockfile, even when `CI` is set.
 
 ## Opting out
 

--- a/docs/docs/cli/1-deps/01-mops-add.md
+++ b/docs/docs/cli/1-deps/01-mops-add.md
@@ -46,11 +46,11 @@ Add package to `[dev-dependencies]` section.
 
 What to do with the [lockfile](/mops.lock)
 
-Default value is `update` if lockfile exists and `ignore` otherwise.
+Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 
 Possible values:
-- `update` - update lockfile (create if not exists). Always checks after update
-- `ignore` - ignore lockfile
+- `update` — update lockfile (create if not exists). Always checks after update
+- `ignore` — ignore lockfile
 
 ### `--verbose`
 

--- a/docs/docs/cli/1-deps/01-mops-remove.md
+++ b/docs/docs/cli/1-deps/01-mops-remove.md
@@ -22,7 +22,7 @@ Remove package from `[dev-dependencies]` section.
 
 What to do with the [lockfile](/mops.lock).
 
-Default value is `update` if lockfile exists and `ignore` otherwise.
+Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 
 Possible values:
 - `update` - update lockfile (create if not exists). Always checks after update

--- a/docs/docs/cli/1-deps/02-mops-install.md
+++ b/docs/docs/cli/1-deps/02-mops-install.md
@@ -26,7 +26,7 @@ See [mops.lock](/mops.lock) for details on lockfile contents and when to commit 
 What to do with the [lockfile](/mops.lock).
 
 Possible values:
-- `update` — keep the lockfile in sync with current dependencies and verify file integrity (default). Pass explicitly to force regeneration if the lockfile is stale or corrupt.
+- `update` — keep the lockfile in sync with current dependencies and verify file integrity (default outside CI). Pass explicitly to force regeneration if the lockfile is stale or corrupt.
 - `check` — verify file integrity against an existing lockfile; fail if the lockfile is missing or out of date
 - `ignore` — skip the lockfile entirely
 
@@ -40,9 +40,9 @@ Verbose output.
 
 ## CI
 
-**Deprecated:** when the `CI` environment variable is set and `--lock` is omitted, `mops install` still defaults to `--lock check` and prints a deprecation warning. This auto-detection will be removed in a future release — pass `--lock check` explicitly (or a future `mops ci` / `--frozen` mode) to keep failing on a stale lockfile.
+**Deprecated:** when the `CI` environment variable is set and `--lock` is omitted, `mops install` still defaults to `--lock check` and prints a deprecation warning. This auto-detection will be removed in a future release — pass `--lock check` explicitly (and commit `mops.lock`) to keep failing on a missing or stale lockfile.
 
-While the auto-path remains: the lockfile is never auto-created in CI. If no lockfile is present, integrity checking is silently skipped. If the lockfile is stale, install fails and suggests `mops install --lock update`.
+Note: explicit `--lock check` errors when the lock is missing; the deprecated CI auto-path skips a missing lock. If the lockfile is stale, install fails and suggests `mops install --lock update`.
 
 `mops add`, `mops remove`, `mops update`, and `mops sync` are unaffected — they always default to updating the lockfile.
 

--- a/docs/docs/cli/1-deps/02-mops-install.md
+++ b/docs/docs/cli/1-deps/02-mops-install.md
@@ -40,6 +40,10 @@ Verbose output.
 
 ## CI
 
-In CI environments (`CI` env var is set), the default `--lock` mode is `check` instead of `update` — the lockfile is never auto-created in CI. If no lockfile is present in CI, integrity checking is silently skipped.
+**Deprecated:** when the `CI` environment variable is set and `--lock` is omitted, `mops install` still defaults to `--lock check` and prints a deprecation warning. This auto-detection will be removed in a future release — pass `--lock check` explicitly (or a future `mops ci` / `--frozen` mode) to keep failing on a stale lockfile.
+
+While the auto-path remains: the lockfile is never auto-created in CI. If no lockfile is present, integrity checking is silently skipped. If the lockfile is stale, install fails and suggests `mops install --lock update`.
+
+`mops add`, `mops remove`, `mops update`, and `mops sync` are unaffected — they always default to updating the lockfile.
 
 See [CI environments](/mops.lock#ci-environments) on the mops.lock page for full details.

--- a/docs/docs/cli/1-deps/02-mops-install.md
+++ b/docs/docs/cli/1-deps/02-mops-install.md
@@ -40,9 +40,9 @@ Verbose output.
 
 ## CI
 
-**Deprecated:** when the `CI` environment variable is set and `--lock` is omitted, `mops install` still defaults to `--lock check` and prints a deprecation warning. This auto-detection will be removed in a future release — pass `--lock check` explicitly (and commit `mops.lock`) to keep failing on a missing or stale lockfile.
+**Deprecated:** when the `CI` environment variable is set and `--lock` is omitted, `mops install` still defaults to `--lock check` and prints a deprecation warning. This auto-detection will be removed in a future release — pass `--lock check` explicitly (and commit `mops.lock`) to keep failing on a stale lockfile.
 
-Note: explicit `--lock check` errors when the lock is missing; the deprecated CI auto-path skips a missing lock. If the lockfile is stale, install fails and suggests `mops install --lock update`.
+Note: explicit `--lock check` also errors when the lock is missing; the deprecated CI auto-path skips a missing lock. If the lockfile is stale, install fails and suggests `mops install --lock update`.
 
 `mops add`, `mops remove`, `mops update`, and `mops sync` are unaffected — they always default to updating the lockfile.
 

--- a/docs/docs/cli/1-deps/04-mops-update.md
+++ b/docs/docs/cli/1-deps/04-mops-update.md
@@ -46,7 +46,7 @@ Mutually exclusive with [`--major`](#--major).
 
 What to do with the [lockfile](/mops.lock).
 
-Default value is `update` if lockfile exists and `ignore` otherwise.
+Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 
 Possible values:
 - `update` - update lockfile (create if not exists). Always checks after update

--- a/docs/docs/cli/1-deps/05-mops-sync.md
+++ b/docs/docs/cli/1-deps/05-mops-sync.md
@@ -19,7 +19,7 @@ mops sync
 
 What to do with the [lockfile](/mops.lock).
 
-Default value is `update` if lockfile exists and `ignore` otherwise.
+Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 
 Possible values:
 - `update` - update lockfile (create if not exists). Always checks after update


### PR DESCRIPTION
When `CI` is set, `mops install` defaults to `--lock check`. A stale `mops.lock` then failed with "Mismatched mops.toml dependencies hash" and exited before rewriting the lock — with no hint that `--lock update` is the recovery. `mops add` / `remove` / `update` / `sync` inherited the same default even though they never expose `--lock check`, so changing deps under `CI` left the lock permanently out of sync.

**Before** (`CI=1`, stale lock):
```
Integrity check failed
Mismatched mops.toml dependencies hash
Locked hash: …
Actual hash: …
```

**After:**
```
Integrity check failed
Mismatched mops.toml dependencies hash
Locked hash: …
Actual hash: …
Run `mops install --lock update` to regenerate it.
```

Dependency-mutating commands now always default to updating the lockfile, even when `CI` is set. Using `CI` to auto-select `--lock check` on `mops install` still works but prints a deprecation warning — pass `--lock check` explicitly. Removal is tracked in `NEXT-MAJOR.md` ([GH #516](https://github.com/caffeinelabs/mops/issues/516)).

## Migration
CI pipelines that relied on the `CI` env var for frozen installs should switch to `mops install --lock check` (and commit `mops.lock`). Explicit `--lock check` also fails when the lockfile is missing; the deprecated auto-path skips a missing lock.

## What is unchanged
Other `CI` uses (bench markdown, publish prompts, toolchain auto-init) are untouched.