### PR TITLE
ci(release): dispatch ic-mops bump to caffeinelabs/app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,29 @@ jobs:
             --title "CLI v${VERSION}" \
             --notes-file /tmp/release-notes.md
 
+      # --- Notify caffeinelabs/app to bump ic-mops pins ---
+      # Dispatch before canister deploy / artifacts so those failures cannot block the bump.
+
+      - name: Create GitHub App Token for app repo
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        id: app-dispatch-token
+        with:
+          app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
+          private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
+          repositories: app
+
+      - name: Trigger ic-mops bump in app repo
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ steps.app-dispatch-token.outputs.token }}
+          repository: caffeinelabs/app
+          event-type: mops-cli-release
+          client-payload: >-
+            {
+              "version": "${{ steps.version.outputs.version }}",
+              "tag": "${{ github.ref_name }}"
+            }
+
       # --- On-chain release artifacts ---
 
       - name: Generate on-chain release artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,7 @@ jobs:
       # Dispatch before canister deploy / artifacts so those failures cannot block the bump.
 
       - name: Create GitHub App Token for app repo
+        continue-on-error: true
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-dispatch-token
         with:
@@ -162,6 +163,7 @@ jobs:
           repositories: app
 
       - name: Trigger ic-mops bump in app repo
+        continue-on-error: true
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ steps.app-dispatch-token.outputs.token }}


### PR DESCRIPTION
After each CLI release is published to npm and GitHub, notify private `caffeinelabs/app` so it can open the usual two-pin `ic-mops` bump PR.

Dispatch runs immediately after `gh release create`, before canister deploy / artifacts. Notify steps use `continue-on-error` so a dispatch hiccup cannot skip on-chain deploy.

Merge **app first** ([#6933](https://github.com/caffeinelabs/app/pull/6933)), then this, so the listener exists before the next `cli-v*` release.