### PR TITLE
feat(cli): opt-in wasm-opt post-pass for build and bench

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -43,6 +43,12 @@ path = "deployed/backend.most"
 [build]
 outputDir = "src/backend/dist"
 args = ["--release"]
+
+# Opt-in Wasm optimization (Binaryen wasm-opt) for build + bench
+[optimize]
+# level = "O3"       # default
+# keep-names = true  # default
+# wasm-opt pin: [toolchain] wasm-opt = "131" (auto-pinned to latest if missing)
 ```
 
 `check-stable` runs ICP's upgrade-time stable-variable compatibility check locally, so incompatible changes fail in `mops check` instead of being rejected when upgrading a live canister. It compares the current code against a `.most` from the deployed version.
@@ -116,6 +122,8 @@ mops build -- --ai-errors # pass extra moc flags
 
 Produces `.wasm`, `.did`, and `.most` files in `[build].outputDir` (default `.mops/.build`).
 
+With `[optimize]` in `mops.toml`, runs `wasm-opt` after candid metadata (default `-O3 -g`). Pin Binaryen with `mops toolchain use wasm-opt 131` (or let auto-pin write latest on first build). Soft-fails to unoptimized Wasm on error.
+
 ### `mops deployed`
 
 Post-deploy hook — keeps the on-disk `.most` baseline used by `check-stable` in sync with what's actually deployed.
@@ -145,6 +153,7 @@ mops toolchain use moc 1.7.0         # pin specific version
 mops toolchain use moc latest        # pin latest version (non-interactive)
 mops toolchain use lintoko 0.10.0    # pin specific version
 mops toolchain use pocket-ic 12.0.0  # pin for replica tests / benchmarks (pin a specific version; `latest` may resolve to one the bundled pic-js client doesn't support)
+mops toolchain use wasm-opt 131      # Binaryen for [optimize] (or `latest`)
 mops toolchain update moc            # update to latest (requires existing [toolchain] entry)
 mops toolchain update                # update all tools to latest
 mops toolchain info <tool>           # show release info (latest, pinned, history)

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- `[optimize]` runs Binaryen `wasm-opt` after `mops build` / `mops bench` (opt-in). Empty `[optimize]` defaults to `-O3 -g`. Pin via `[toolchain] wasm-opt` (Binaryen version, e.g. `131`); auto-pins latest if missing. Soft-fails to unoptimized Wasm on error.
+
 ## 2.18.0
 
 - `mops toolchain info <tool> --versions` lists stable GitHub release versions for a toolchain tool (moc, lintoko, wasmtime, pocket-ic), one per line, newest first. Defaults to the first releases page; pass `--all` for the full history (cache warming).

--- a/cli/commands/bench-replica.ts
+++ b/cli/commands/bench-replica.ts
@@ -3,7 +3,7 @@ import { execSync } from "node:child_process";
 import path from "node:path";
 import fs from "node:fs";
 import { execaCommand } from "execa";
-import { getRootDir, readConfig } from "../mops.js";
+import { getRootDir } from "../mops.js";
 import {
   type AnyPocketIcServer,
   type AnyPocketIc,
@@ -13,7 +13,6 @@ import {
 import { createActor, idlFactory } from "../declarations/bench/index.js";
 import { toolchain } from "./toolchain/index.js";
 import { getDfxVersion } from "../helpers/get-dfx-version.js";
-import { isOptimizeEnabled } from "../helpers/optimize-config.js";
 
 export class BenchReplica {
   type: "dfx" | "pocket-ic" | "dfx-pocket-ic";
@@ -107,7 +106,10 @@ export class BenchReplica {
     return this.canisters[name]?.canisterId || "";
   }
 
-  dfxJson(canisterName: string) {
+  dfxJson(
+    canisterName: string,
+    { skipDfxOptimize = false }: { skipDfxOptimize?: boolean } = {},
+  ) {
     let canisters: Record<string, any> = {};
     if (canisterName) {
       let canister: Record<string, unknown> = {
@@ -115,8 +117,8 @@ export class BenchReplica {
         wasm: "canister.wasm",
         candid: "canister.did",
       };
-      // mops already ran wasm-opt; avoid a second (stale ic-wasm) pass on deploy
-      if (!isOptimizeEnabled(readConfig())) {
+      // Only skip dfx's pass when mops already optimized successfully
+      if (!skipDfxOptimize) {
         canister.optimize = "cycles";
       }
       canisters[canisterName] = canister;

--- a/cli/commands/bench-replica.ts
+++ b/cli/commands/bench-replica.ts
@@ -3,7 +3,7 @@ import { execSync } from "node:child_process";
 import path from "node:path";
 import fs from "node:fs";
 import { execaCommand } from "execa";
-import { getRootDir } from "../mops.js";
+import { getRootDir, readConfig } from "../mops.js";
 import {
   type AnyPocketIcServer,
   type AnyPocketIc,
@@ -13,6 +13,7 @@ import {
 import { createActor, idlFactory } from "../declarations/bench/index.js";
 import { toolchain } from "./toolchain/index.js";
 import { getDfxVersion } from "../helpers/get-dfx-version.js";
+import { isOptimizeEnabled } from "../helpers/optimize-config.js";
 
 export class BenchReplica {
   type: "dfx" | "pocket-ic" | "dfx-pocket-ic";
@@ -109,12 +110,16 @@ export class BenchReplica {
   dfxJson(canisterName: string) {
     let canisters: Record<string, any> = {};
     if (canisterName) {
-      canisters[canisterName] = {
+      let canister: Record<string, unknown> = {
         type: "custom",
         wasm: "canister.wasm",
         candid: "canister.did",
-        optimize: "cycles",
       };
+      // mops already ran wasm-opt; avoid a second (stale ic-wasm) pass on deploy
+      if (!isOptimizeEnabled(readConfig())) {
+        canister.optimize = "cycles";
+      }
+      canisters[canisterName] = canister;
     }
 
     return {

--- a/cli/commands/bench.ts
+++ b/cli/commands/bench.ts
@@ -348,10 +348,6 @@ async function deployBenchFile(
 
   // prepare temp files
   fs.mkdirSync(tempDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(tempDir, "dfx.json"),
-    JSON.stringify(replica.dfxJson(canisterName), null, 2),
-  );
 
   let benchCanisterData = fs.readFileSync(
     new URL("./bench/bench-canister.mo", import.meta.url),
@@ -390,7 +386,17 @@ async function deployBenchFile(
 
   // deploy canister
   let wasm = path.join(tempDir, "canister.wasm");
-  await optimizeWasm(wasm, readConfig(), { verbose: options.verbose });
+  let optimized = await optimizeWasm(wasm, readConfig(), {
+    verbose: options.verbose,
+  });
+  fs.writeFileSync(
+    path.join(tempDir, "dfx.json"),
+    JSON.stringify(
+      replica.dfxJson(canisterName, { skipDfxOptimize: optimized }),
+      null,
+      2,
+    ),
+  );
   options.verbose && console.time(`deploy ${canisterName}`);
   // await execaCommand(`dfx deploy ${canisterName} --mode reinstall --yes --identity anonymous`, {cwd: tempDir, stdio: options.verbose ? 'pipe' : ['pipe', 'ignore', 'pipe']});
   await replica.deploy(canisterName, wasm, tempDir);

--- a/cli/commands/bench.ts
+++ b/cli/commands/bench.ts
@@ -24,6 +24,10 @@ import { getMocVersion } from "../helpers/get-moc-version.js";
 import { getDfxVersion } from "../helpers/get-dfx-version.js";
 import { warnIfDfxReplica } from "../helpers/deprecate-dfx-replica.js";
 import { getMocPath } from "../helpers/get-moc-path.js";
+import {
+  formatOptimizePipeline,
+  optimizeWasm,
+} from "../helpers/optimize-wasm.js";
 import { sourcesArgs } from "./sources.js";
 import { MOTOKO_GLOB_CONFIG } from "../constants.js";
 
@@ -108,12 +112,14 @@ export async function bench(
   warnIfDfxReplica(replicaType, optionsArg.replica === "dfx");
 
   if (options.verbose) {
-    // `dfx` post-optimizes the wasm on deploy (`optimize: "cycles"`, via ic-wasm);
-    // `pocket-ic` runs the raw moc output. This changes instruction counts, so surface it.
-    let optimize =
-      replicaType === "dfx" || replicaType === "dfx-pocket-ic"
-        ? 'dfx `optimize: "cycles"` (ic-wasm) on deploy'
-        : "none (raw moc output)";
+    // Without [optimize], dfx still post-optimizes on deploy; pocket-ic runs raw moc output.
+    let optimize = formatOptimizePipeline(config);
+    if (optimize === "none (raw moc output)") {
+      optimize =
+        replicaType === "dfx" || replicaType === "dfx-pocket-ic"
+          ? 'dfx `optimize: "cycles"` (ic-wasm) on deploy'
+          : optimize;
+    }
     let legacyGc = isLegacyGc(options.gc);
     let effectiveLegacyPersistence = options.legacyPersistence || legacyGc;
     console.log(chalk.gray("Benchmark pipeline:"));
@@ -384,6 +390,7 @@ async function deployBenchFile(
 
   // deploy canister
   let wasm = path.join(tempDir, "canister.wasm");
+  await optimizeWasm(wasm, readConfig(), { verbose: options.verbose });
   options.verbose && console.time(`deploy ${canisterName}`);
   // await execaCommand(`dfx deploy ${canisterName} --mode reinstall --yes --identity anonymous`, {cwd: tempDir, stdio: options.verbose ? 'pipe' : ['pipe', 'ignore', 'pipe']});
   await replica.deploy(canisterName, wasm, tempDir);

--- a/cli/commands/build.ts
+++ b/cli/commands/build.ts
@@ -11,6 +11,7 @@ import {
   resolveCanisterConfigs,
 } from "../helpers/resolve-canisters.js";
 import { BUILD_MANAGED_FLAGS, prepareMocArgs } from "../helpers/moc-args.js";
+import { optimizeWasm } from "../helpers/optimize-wasm.js";
 import { CustomSection, getWasmBindings } from "../wasm.js";
 import { readConfig, resolveConfigPath } from "../mops.js";
 import { Config } from "../types.js";
@@ -200,6 +201,7 @@ export async function build(
           customSections,
         );
         await writeFile(wasmPath, newWasm);
+        await optimizeWasm(wasmPath, config, { verbose: options.verbose });
       } catch (err: any) {
         if (err.message?.includes("Build failed for canister")) {
           throw err;

--- a/cli/commands/toolchain/index.ts
+++ b/cli/commands/toolchain/index.ts
@@ -20,6 +20,7 @@ import * as moc from "./moc.js";
 import * as pocketIc from "./pocket-ic.js";
 import * as wasmtime from "./wasmtime.js";
 import * as lintoko from "./lintoko.js";
+import * as wasmOpt from "./wasm-opt.js";
 import { FILE_PATH_REGEX } from "../../constants.js";
 import * as toolchainUtils from "./toolchain-utils.js";
 import type { ReleaseInfo } from "./release-tags.js";
@@ -42,6 +43,8 @@ function getToolUtils(tool: Tool) {
     return wasmtime;
   } else if (tool === "lintoko") {
     return lintoko;
+  } else if (tool === "wasm-opt") {
+    return wasmOpt;
   } else {
     console.error(`Unknown tool '${tool}'`);
     process.exit(1);
@@ -239,6 +242,12 @@ async function installAll({ silent = false, verbose = false } = {}) {
   }
   if (config.toolchain?.lintoko) {
     await download("lintoko", config.toolchain.lintoko, { silent, verbose });
+  }
+  if (config.toolchain?.["wasm-opt"]) {
+    await download("wasm-opt", config.toolchain["wasm-opt"], {
+      silent,
+      verbose,
+    });
   }
 
   if (!silent) {

--- a/cli/commands/toolchain/index.ts
+++ b/cli/commands/toolchain/index.ts
@@ -456,6 +456,8 @@ async function bin(tool: Tool, { fallback = false } = {}): Promise<string> {
 
     if (tool === "moc") {
       return path.join(globalCacheDir, "moc", version, tool);
+    } else if (tool === "wasm-opt") {
+      return path.join(globalCacheDir, "wasm-opt", version, "bin", "wasm-opt");
     } else {
       return path.join(globalCacheDir, tool, version, tool);
     }

--- a/cli/commands/toolchain/index.ts
+++ b/cli/commands/toolchain/index.ts
@@ -24,9 +24,15 @@ import * as wasmOpt from "./wasm-opt.js";
 import { FILE_PATH_REGEX } from "../../constants.js";
 import * as toolchainUtils from "./toolchain-utils.js";
 import type { ReleaseInfo } from "./release-tags.js";
+import { normalizeBinaryenVersion } from "../../helpers/binaryen-version.js";
 
 function label(text: string): string {
   return chalk.bold(text.padEnd(16));
+}
+
+/** Map GitHub tags to the pin format stored in mops.toml (Binaryen: `version_131` → `131`). */
+function normalizeReleaseTag(tool: Tool, tag: string): string {
+  return tool === "wasm-opt" ? normalizeBinaryenVersion(tag) : tag;
 }
 
 export interface ToolchainInfoOptions {
@@ -378,16 +384,22 @@ async function info(tool: Tool, options: ToolchainInfoOptions = {}) {
       all: options.all,
     });
     for (let ver of tags) {
-      console.log(ver);
+      console.log(normalizeReleaseTag(tool, ver));
     }
     return;
   }
 
   // First page only — enough for latest + a short history preview.
-  let { tags, truncated, publishedLatest } =
-    await toolchainUtils.getStableReleaseTags(toolUtils.repo);
+  let {
+    tags: rawTags,
+    truncated,
+    publishedLatest,
+  } = await toolchainUtils.getStableReleaseTags(toolUtils.repo);
+  let tags = rawTags.map((tag) => normalizeReleaseTag(tool, tag));
 
-  let latest = publishedLatest ?? (await toolUtils.getLatestReleaseTag());
+  let latest = publishedLatest
+    ? normalizeReleaseTag(tool, publishedLatest)
+    : await toolUtils.getLatestReleaseTag();
 
   let configFile = getClosestConfigFile();
   let pinned = configFile

--- a/cli/commands/toolchain/toolchain-utils.ts
+++ b/cli/commands/toolchain/toolchain-utils.ts
@@ -16,7 +16,13 @@ import { stableReleaseTags, type ReleaseInfo } from "./release-tags.js";
 export type { ReleaseInfo } from "./release-tags.js";
 export { sortReleaseTags, stableReleaseTags } from "./release-tags.js";
 
-export const TOOLCHAINS = ["moc", "wasmtime", "pocket-ic", "lintoko"];
+export const TOOLCHAINS = [
+  "moc",
+  "wasmtime",
+  "pocket-ic",
+  "lintoko",
+  "wasm-opt",
+];
 
 export let tryDownloadFile = async (url: string): Promise<Buffer | null> => {
   let res = await fetch(url);

--- a/cli/commands/toolchain/wasm-opt.ts
+++ b/cli/commands/toolchain/wasm-opt.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import fs from "fs-extra";
 import { chmodSync } from "node:fs";
 import { Octokit } from "octokit";
+import { execa } from "execa";
 
 import { globalCacheDir } from "../../mops.js";
 import * as toolchainUtils from "./toolchain-utils.js";
@@ -14,6 +15,10 @@ export { normalizeBinaryenVersion } from "../../helpers/binaryen-version.js";
 let cacheDir = path.join(globalCacheDir, "wasm-opt");
 
 export let repo = "WebAssembly/binaryen";
+
+/** Resolved wasm-opt path inside a versioned cache dir (keeps sibling `lib/` for rpath). */
+export let binaryPath = (version: string) =>
+  path.join(cacheDir, version, "bin", "wasm-opt");
 
 export let getLatestReleaseTag = async () => {
   let octokit = new Octokit();
@@ -52,8 +57,7 @@ export let getReleases = async (): Promise<ReleaseInfo[]> => {
 };
 
 export let isCached = (version: string) => {
-  let dir = path.join(cacheDir, version);
-  return fs.existsSync(dir) && fs.existsSync(path.join(dir, "wasm-opt"));
+  return fs.existsSync(binaryPath(version));
 };
 
 export let download = async (
@@ -62,6 +66,10 @@ export let download = async (
 ) => {
   if (!version) {
     console.error("version is not defined");
+    process.exit(1);
+  }
+  if (process.platform === "win32") {
+    console.error("wasm-opt toolchain is not supported on Windows");
     process.exit(1);
   }
   if (isCached(version)) {
@@ -89,18 +97,35 @@ export let download = async (
   }
 
   let destDir = path.join(cacheDir, version);
-  await toolchainUtils.downloadAndExtract(url, destDir);
+  // Fresh extract into a temp sibling, then replace — avoids a half-cached broken install.
+  let stagingDir = path.join(cacheDir, `.${version}.staging`);
+  await fs.remove(stagingDir);
+  await fs.remove(destDir);
+  await toolchainUtils.downloadAndExtract(url, stagingDir);
 
-  // Tarball nests bin/ under binaryen-version_N/; flatten to match other tools.
-  let nestedBin = path.join(destDir, `binaryen-${tag}`, "bin", "wasm-opt");
-  let flatBin = path.join(destDir, "wasm-opt");
+  // Keep bin/ + lib/ (wasm-opt is linked with @rpath → ../lib/libbinaryen).
+  let nestedRoot = path.join(stagingDir, `binaryen-${tag}`);
+  let nestedBin = path.join(nestedRoot, "bin", "wasm-opt");
   if (!fs.existsSync(nestedBin)) {
+    await fs.remove(stagingDir);
     console.error(
       `wasm-opt binary not found in Binaryen archive: ${nestedBin}`,
     );
     process.exit(1);
   }
-  fs.moveSync(nestedBin, flatBin);
-  chmodSync(flatBin, 0o700);
-  fs.removeSync(path.join(destDir, `binaryen-${tag}`));
+  await fs.move(path.join(nestedRoot, "bin"), path.join(destDir, "bin"));
+  await fs.move(path.join(nestedRoot, "lib"), path.join(destDir, "lib"));
+  chmodSync(path.join(destDir, "bin", "wasm-opt"), 0o700);
+  await fs.remove(stagingDir);
+
+  let smoke = await execa(binaryPath(version), ["--version"], {
+    reject: false,
+  });
+  if (smoke.exitCode !== 0) {
+    await fs.remove(destDir);
+    console.error(
+      `wasm-opt ${version} failed to run after install${smoke.stderr ? `: ${smoke.stderr.trim()}` : ""}`,
+    );
+    process.exit(1);
+  }
 };

--- a/cli/commands/toolchain/wasm-opt.ts
+++ b/cli/commands/toolchain/wasm-opt.ts
@@ -1,0 +1,106 @@
+import process from "node:process";
+import path from "node:path";
+import fs from "fs-extra";
+import { chmodSync } from "node:fs";
+import { Octokit } from "octokit";
+
+import { globalCacheDir } from "../../mops.js";
+import * as toolchainUtils from "./toolchain-utils.js";
+import type { ReleaseInfo } from "./release-tags.js";
+import { normalizeBinaryenVersion } from "../../helpers/binaryen-version.js";
+
+export { normalizeBinaryenVersion } from "../../helpers/binaryen-version.js";
+
+let cacheDir = path.join(globalCacheDir, "wasm-opt");
+
+export let repo = "WebAssembly/binaryen";
+
+export let getLatestReleaseTag = async () => {
+  let octokit = new Octokit();
+  for (let page = 1; ; page++) {
+    let res = await octokit.request(`GET /repos/${repo}/releases`, {
+      per_page: 100,
+      page,
+      headers: { "X-GitHub-Api-Version": "2022-11-28" },
+    });
+    if (res.status !== 200) {
+      console.error("Releases fetch error");
+      process.exit(1);
+    }
+    if (res.data.length === 0) {
+      break;
+    }
+    for (let release of res.data) {
+      if (!release.draft && !release.prerelease) {
+        return normalizeBinaryenVersion(release.tag_name);
+      }
+    }
+    if (res.data.length < 100) {
+      break;
+    }
+  }
+  console.error(`Failed to fetch latest release tag for ${repo}`);
+  process.exit(1);
+};
+
+export let getReleases = async (): Promise<ReleaseInfo[]> => {
+  let releases = await toolchainUtils.getReleases(repo);
+  return releases.map((r) => ({
+    ...r,
+    tag_name: normalizeBinaryenVersion(r.tag_name),
+  }));
+};
+
+export let isCached = (version: string) => {
+  let dir = path.join(cacheDir, version);
+  return fs.existsSync(dir) && fs.existsSync(path.join(dir, "wasm-opt"));
+};
+
+export let download = async (
+  version: string,
+  { silent = false, verbose = false } = {},
+) => {
+  if (!version) {
+    console.error("version is not defined");
+    process.exit(1);
+  }
+  if (isCached(version)) {
+    if (verbose) {
+      console.log(`wasm-opt ${version} is already installed`);
+    }
+    return;
+  }
+
+  // GitHub assets: x86_64-linux, aarch64-linux, x86_64-macos, arm64-macos
+  let platform = process.platform == "darwin" ? "macos" : "linux";
+  let arch =
+    process.platform == "darwin"
+      ? process.arch.startsWith("arm")
+        ? "arm64"
+        : "x86_64"
+      : process.arch.startsWith("arm")
+        ? "aarch64"
+        : "x86_64";
+  let tag = `version_${version}`;
+  let url = `https://github.com/WebAssembly/binaryen/releases/download/${tag}/binaryen-${tag}-${arch}-${platform}.tar.gz`;
+
+  if (verbose && !silent) {
+    console.log(`Downloading ${url}`);
+  }
+
+  let destDir = path.join(cacheDir, version);
+  await toolchainUtils.downloadAndExtract(url, destDir);
+
+  // Tarball nests bin/ under binaryen-version_N/; flatten to match other tools.
+  let nestedBin = path.join(destDir, `binaryen-${tag}`, "bin", "wasm-opt");
+  let flatBin = path.join(destDir, "wasm-opt");
+  if (!fs.existsSync(nestedBin)) {
+    console.error(
+      `wasm-opt binary not found in Binaryen archive: ${nestedBin}`,
+    );
+    process.exit(1);
+  }
+  fs.moveSync(nestedBin, flatBin);
+  chmodSync(flatBin, 0o700);
+  fs.removeSync(path.join(destDir, `binaryen-${tag}`));
+};

--- a/cli/commands/toolchain/wasm-opt.ts
+++ b/cli/commands/toolchain/wasm-opt.ts
@@ -57,7 +57,10 @@ export let getReleases = async (): Promise<ReleaseInfo[]> => {
 };
 
 export let isCached = (version: string) => {
-  return fs.existsSync(binaryPath(version));
+  let dir = path.join(cacheDir, version);
+  return (
+    fs.existsSync(binaryPath(version)) && fs.existsSync(path.join(dir, "lib"))
+  );
 };
 
 export let download = async (
@@ -113,18 +116,23 @@ export let download = async (
     );
     process.exit(1);
   }
-  await fs.move(path.join(nestedRoot, "bin"), path.join(destDir, "bin"));
-  await fs.move(path.join(nestedRoot, "lib"), path.join(destDir, "lib"));
-  chmodSync(path.join(destDir, "bin", "wasm-opt"), 0o700);
-  await fs.remove(stagingDir);
+  try {
+    await fs.move(path.join(nestedRoot, "bin"), path.join(destDir, "bin"));
+    await fs.move(path.join(nestedRoot, "lib"), path.join(destDir, "lib"));
+    chmodSync(path.join(destDir, "bin", "wasm-opt"), 0o700);
+    await fs.remove(stagingDir);
 
-  let smoke = await execa(binaryPath(version), ["--version"], {
-    reject: false,
-  });
-  if (smoke.exitCode !== 0) {
+    let smoke = await execa(binaryPath(version), ["--version"], {
+      reject: false,
+    });
+    if (smoke.exitCode !== 0) {
+      throw new Error(smoke.stderr?.trim() || `exit code ${smoke.exitCode}`);
+    }
+  } catch (err: any) {
     await fs.remove(destDir);
+    await fs.remove(stagingDir);
     console.error(
-      `wasm-opt ${version} failed to run after install${smoke.stderr ? `: ${smoke.stderr.trim()}` : ""}`,
+      `wasm-opt ${version} failed to install${err?.message ? `: ${err.message}` : ""}`,
     );
     process.exit(1);
   }

--- a/cli/helpers/binaryen-version.ts
+++ b/cli/helpers/binaryen-version.ts
@@ -1,0 +1,11 @@
+/** Binaryen tags are `version_131`; mops pins `131`. */
+export let normalizeBinaryenVersion = (tag: string): string => {
+  if (tag.startsWith("version_")) {
+    return tag.slice("version_".length);
+  }
+  // Generic toolchain helpers strip a leading `v`, turning `version_131` into `ersion_131`.
+  if (tag.startsWith("ersion_")) {
+    return tag.slice("ersion_".length);
+  }
+  return tag.replace(/^v/, "");
+};

--- a/cli/helpers/optimize-config.ts
+++ b/cli/helpers/optimize-config.ts
@@ -8,9 +8,13 @@ export type OptimizeResolved = {
   args: string[];
 };
 
-/** `[optimize]` present (including empty table) enables the post-pass. */
+/** `[optimize]` present as a table (including empty) enables the post-pass. */
 export function isOptimizeEnabled(config: Config): boolean {
-  return config.optimize !== undefined;
+  return (
+    typeof config.optimize === "object" &&
+    config.optimize !== null &&
+    !Array.isArray(config.optimize)
+  );
 }
 
 export function resolveOptimizeConfig(config: Config): OptimizeResolved | null {

--- a/cli/helpers/optimize-config.ts
+++ b/cli/helpers/optimize-config.ts
@@ -1,0 +1,47 @@
+import type { Config } from "../types.js";
+
+const OPT_LEVELS = new Set(["O0", "O1", "O2", "O3", "O4", "Os", "Oz"]);
+
+export type OptimizeResolved = {
+  level: string;
+  keepNames: boolean;
+  args: string[];
+};
+
+/** `[optimize]` present (including empty table) enables the post-pass. */
+export function isOptimizeEnabled(config: Config): boolean {
+  return config.optimize !== undefined;
+}
+
+export function resolveOptimizeConfig(config: Config): OptimizeResolved | null {
+  if (!isOptimizeEnabled(config)) {
+    return null;
+  }
+  let level = config.optimize?.level ?? "O3";
+  if (!OPT_LEVELS.has(level)) {
+    throw new Error(
+      `Invalid [optimize].level "${level}". Expected one of: ${[...OPT_LEVELS].join(", ")}`,
+    );
+  }
+  let keepNames = config.optimize?.["keep-names"] ?? true;
+  let args = config.optimize?.args ?? [];
+  if (!Array.isArray(args) || args.some((a) => typeof a !== "string")) {
+    throw new Error(`[optimize].args must be an array of strings`);
+  }
+  return { level, keepNames, args };
+}
+
+/** Describe the active optimize settings for bench/build verbose output. */
+export function formatOptimizePipeline(config: Config): string {
+  let resolved = resolveOptimizeConfig(config);
+  if (!resolved) {
+    return "none (raw moc output)";
+  }
+  let version = config.toolchain?.["wasm-opt"] ?? "auto";
+  let flags = [`-${resolved.level}`];
+  if (resolved.keepNames) {
+    flags.push("-g");
+  }
+  flags.push(...resolved.args);
+  return `wasm-opt ${version} ${flags.join(" ")}`;
+}

--- a/cli/helpers/optimize-wasm.ts
+++ b/cli/helpers/optimize-wasm.ts
@@ -1,0 +1,135 @@
+import path from "node:path";
+import fs from "fs-extra";
+import chalk from "chalk";
+import { execa } from "execa";
+
+import { readConfig, writeConfig, getClosestConfigFile } from "../mops.js";
+import type { Config } from "../types.js";
+import { cliError } from "../error.js";
+import { toolchain } from "../commands/toolchain/index.js";
+import { getLatestReleaseTag } from "../commands/toolchain/wasm-opt.js";
+import {
+  formatOptimizePipeline,
+  isOptimizeEnabled,
+  resolveOptimizeConfig,
+} from "./optimize-config.js";
+
+export {
+  formatOptimizePipeline,
+  isOptimizeEnabled,
+  resolveOptimizeConfig,
+} from "./optimize-config.js";
+export type { OptimizeResolved } from "./optimize-config.js";
+
+function resolveOptimizeConfigOrExit(config: Config) {
+  try {
+    return resolveOptimizeConfig(config);
+  } catch (err: any) {
+    cliError(err?.message ?? String(err));
+  }
+}
+/**
+ * If `[optimize]` is on and `[toolchain].wasm-opt` is missing, pin the latest
+ * Binaryen release into mops.toml and return its version.
+ */
+export async function ensureWasmOptPinned(
+  config: Config = readConfig(),
+  { verbose = false } = {},
+): Promise<string | null> {
+  if (!isOptimizeEnabled(config)) {
+    return null;
+  }
+  let existing = config.toolchain?.["wasm-opt"];
+  if (existing) {
+    return existing;
+  }
+  let version = await getLatestReleaseTag();
+  config.toolchain = { ...config.toolchain, "wasm-opt": version };
+  writeConfig(config);
+  console.log(
+    chalk.yellow(
+      `Pinned wasm-opt ${version} in ${path.basename(getClosestConfigFile())} ([optimize] enabled)`,
+    ),
+  );
+  if (verbose) {
+    console.log(chalk.gray(`  [toolchain] wasm-opt = "${version}"`));
+  }
+  return version;
+}
+
+export type OptimizeWasmOptions = {
+  verbose?: boolean;
+};
+
+/**
+ * Run wasm-opt on a Wasm file in place when `[optimize]` is enabled.
+ * On failure: warn and leave the unoptimized file.
+ */
+export async function optimizeWasm(
+  wasmPath: string,
+  config: Config = readConfig(),
+  options: OptimizeWasmOptions = {},
+): Promise<boolean> {
+  let resolved = resolveOptimizeConfigOrExit(config);
+  if (!resolved) {
+    return false;
+  }
+
+  await ensureWasmOptPinned(config, { verbose: options.verbose });
+  // Re-read in case auto-pin wrote toolchain; callers may pass a stale object.
+  config = readConfig();
+  let wasmOptBin = await toolchain.bin("wasm-opt");
+
+  let tmpPath = `${wasmPath}.opt`;
+  let args = [
+    `-${resolved.level}`,
+    ...(resolved.keepNames ? ["-g"] : []),
+    ...resolved.args,
+    wasmPath,
+    "-o",
+    tmpPath,
+  ];
+
+  if (options.verbose) {
+    console.log(chalk.gray(`${wasmOptBin} ${args.join(" ")}`));
+  }
+
+  try {
+    let result = await execa(wasmOptBin, args, {
+      reject: false,
+      all: true,
+    });
+    if (result.exitCode !== 0) {
+      console.warn(
+        chalk.yellow(
+          `Failed to optimize ${path.basename(wasmPath)} with wasm-opt; using unoptimized Wasm`,
+        ),
+      );
+      if (options.verbose && result.all) {
+        console.warn(chalk.gray(result.all));
+      } else if (result.stderr) {
+        console.warn(chalk.gray(result.stderr.trim()));
+      }
+      await fs.remove(tmpPath).catch(() => {});
+      return false;
+    }
+    await fs.move(tmpPath, wasmPath, { overwrite: true });
+    console.log(
+      chalk.gray(
+        `Optimized ${path.basename(wasmPath)} (${formatOptimizePipeline(config)})`,
+      ),
+    );
+    return true;
+  } catch (err: any) {
+    console.warn(
+      chalk.yellow(
+        `Failed to optimize ${path.basename(wasmPath)} with wasm-opt; using unoptimized Wasm`,
+      ),
+    );
+    if (options.verbose && err?.message) {
+      console.warn(chalk.gray(err.message));
+    }
+    await fs.remove(tmpPath).catch(() => {});
+    return false;
+  }
+}

--- a/cli/tests/build.test.ts
+++ b/cli/tests/build.test.ts
@@ -140,4 +140,33 @@ describe("build", () => {
       }
     },
   );
+
+  test("[optimize] runs wasm-opt after build", async () => {
+    const cwd = path.join(import.meta.dirname, "build/optimize");
+    const stamp = path.join(cwd, ".mops/.build/.wasm-opt-ran");
+    try {
+      const result = await cli(["build", "--verbose"], { cwd });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).toMatch(/Optimized main\.wasm/);
+      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(true);
+      expect(existsSync(stamp)).toBe(true);
+    } finally {
+      cleanFixture(cwd);
+      rmSync(stamp, { force: true });
+    }
+  });
+
+  test("[optimize] soft-fails when wasm-opt errors", async () => {
+    const cwd = path.join(import.meta.dirname, "build/optimize-fail");
+    try {
+      const result = await cli(["build"], { cwd });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).toMatch(
+        /Failed to optimize main\.wasm/,
+      );
+      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(true);
+    } finally {
+      cleanFixture(cwd);
+    }
+  });
 });

--- a/cli/tests/build/optimize-fail/mock-wasm-opt
+++ b/cli/tests/build/optimize-fail/mock-wasm-opt
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "mock-wasm-opt: intentional failure" >&2
+exit 1

--- a/cli/tests/build/optimize-fail/mops.toml
+++ b/cli/tests/build/optimize-fail/mops.toml
@@ -1,0 +1,11 @@
+[dependencies]
+core = "1.0.0"
+
+[toolchain]
+wasm-opt = "./mock-wasm-opt"
+
+[canisters.main]
+main = "src/Main.mo"
+
+[optimize]
+level = "O3"

--- a/cli/tests/build/optimize-fail/src/Main.mo
+++ b/cli/tests/build/optimize-fail/src/Main.mo
@@ -1,0 +1,3 @@
+persistent actor {
+  public query func g() : async () {};
+};

--- a/cli/tests/build/optimize/mock-wasm-opt
+++ b/cli/tests/build/optimize/mock-wasm-opt
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+infile=""
+prev=""
+for a in "$@"; do
+  if [[ "$prev" == "-o" ]]; then
+    out="$a"
+    prev=""
+    continue
+  fi
+  if [[ "$a" == "-o" ]]; then
+    prev="-o"
+    continue
+  fi
+  if [[ "$a" != -* ]]; then
+    infile="$a"
+  fi
+  prev="$a"
+done
+if [[ -z "$infile" || -z "$out" ]]; then
+  echo "mock-wasm-opt: missing input or -o" >&2
+  exit 1
+fi
+cp "$infile" "$out"
+# stamp so tests can assert the mock ran
+touch "$(dirname "$infile")/.wasm-opt-ran"

--- a/cli/tests/build/optimize/mops.toml
+++ b/cli/tests/build/optimize/mops.toml
@@ -1,0 +1,10 @@
+[dependencies]
+core = "1.0.0"
+
+[toolchain]
+wasm-opt = "./mock-wasm-opt"
+
+[canisters.main]
+main = "src/Main.mo"
+
+[optimize]

--- a/cli/tests/build/optimize/src/Main.mo
+++ b/cli/tests/build/optimize/src/Main.mo
@@ -1,0 +1,3 @@
+persistent actor {
+  public query func g() : async () {};
+};

--- a/cli/tests/optimize-wasm.test.ts
+++ b/cli/tests/optimize-wasm.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "@jest/globals";
+import { normalizeBinaryenVersion } from "../helpers/binaryen-version";
+import type { Config } from "../types";
+import {
+  formatOptimizePipeline,
+  isOptimizeEnabled,
+  resolveOptimizeConfig,
+} from "../helpers/optimize-config";
+
+describe("optimize-config", () => {
+  test("isOptimizeEnabled: absent vs empty table", () => {
+    expect(isOptimizeEnabled({} as Config)).toBe(false);
+    expect(isOptimizeEnabled({ optimize: {} } as Config)).toBe(true);
+  });
+
+  test("resolveOptimizeConfig defaults", () => {
+    expect(resolveOptimizeConfig({ optimize: {} } as Config)).toEqual({
+      level: "O3",
+      keepNames: true,
+      args: [],
+    });
+  });
+
+  test("resolveOptimizeConfig overrides", () => {
+    expect(
+      resolveOptimizeConfig({
+        optimize: {
+          level: "Oz",
+          "keep-names": false,
+          args: ["--enable-bulk-memory"],
+        },
+      } as Config),
+    ).toEqual({
+      level: "Oz",
+      keepNames: false,
+      args: ["--enable-bulk-memory"],
+    });
+  });
+
+  test("formatOptimizePipeline", () => {
+    expect(formatOptimizePipeline({} as Config)).toBe("none (raw moc output)");
+    expect(
+      formatOptimizePipeline({
+        optimize: {},
+        toolchain: { "wasm-opt": "131" },
+      } as Config),
+    ).toBe("wasm-opt 131 -O3 -g");
+    expect(
+      formatOptimizePipeline({
+        optimize: { level: "Oz", "keep-names": false },
+        toolchain: { "wasm-opt": "131" },
+      } as Config),
+    ).toBe("wasm-opt 131 -Oz");
+  });
+
+  test("normalizeBinaryenVersion", () => {
+    expect(normalizeBinaryenVersion("version_131")).toBe("131");
+    expect(normalizeBinaryenVersion("ersion_131")).toBe("131");
+    expect(normalizeBinaryenVersion("131")).toBe("131");
+  });
+});

--- a/cli/tests/optimize-wasm.test.ts
+++ b/cli/tests/optimize-wasm.test.ts
@@ -11,6 +11,12 @@ describe("optimize-config", () => {
   test("isOptimizeEnabled: absent vs empty table", () => {
     expect(isOptimizeEnabled({} as Config)).toBe(false);
     expect(isOptimizeEnabled({ optimize: {} } as Config)).toBe(true);
+    expect(isOptimizeEnabled({ optimize: false } as unknown as Config)).toBe(
+      false,
+    );
+    expect(isOptimizeEnabled({ optimize: true } as unknown as Config)).toBe(
+      false,
+    );
   });
 
   test("resolveOptimizeConfig defaults", () => {

--- a/cli/tests/toolchain.test.ts
+++ b/cli/tests/toolchain.test.ts
@@ -22,4 +22,11 @@ describe("toolchain", () => {
     const result = await cli(["install"], { cwd });
     expect(result.stderr).not.toContain("Invalid Version");
   });
+
+  test("wasm-opt file URI", async () => {
+    const cwd = path.join(import.meta.dirname, "build/optimize");
+    const result = await cli(["toolchain", "bin", "wasm-opt"], { cwd });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("./mock-wasm-opt");
+  });
 });

--- a/cli/types.ts
+++ b/cli/types.ts
@@ -36,6 +36,12 @@ export type Config = {
     extends?: string[] | true;
     extra?: Record<string, string[]>;
   };
+  /** Post-build Wasm optimization via Binaryen wasm-opt. Section present (even empty) enables it. */
+  optimize?: {
+    level?: string;
+    "keep-names"?: boolean;
+    args?: string[];
+  };
 };
 
 export type MigrationsConfig = {
@@ -72,9 +78,10 @@ export type Toolchain = {
   wasmtime?: string;
   "pocket-ic"?: string;
   lintoko?: string;
+  "wasm-opt"?: string;
 };
 
-export type Tool = "moc" | "wasmtime" | "pocket-ic" | "lintoko";
+export type Tool = "moc" | "wasmtime" | "pocket-ic" | "lintoko" | "wasm-opt";
 
 export type Requirements = {
   moc?: string;

--- a/docs/docs/09-mops.toml.md
+++ b/docs/docs/09-mops.toml.md
@@ -220,7 +220,7 @@ keep-names = false
 args = ["--enable-bulk-memory"]
 ```
 
-Pin Binaryen via `[toolchain] wasm-opt` (e.g. `"131"`). If `[optimize]` is set and `wasm-opt` is not pinned, mops auto-pins the latest Binaryen release into `mops.toml` on the next build/bench.
+Pin Binaryen via `[toolchain] wasm-opt` (e.g. `"131"`). If `[optimize]` is set and `wasm-opt` is not pinned, mops auto-pins the latest Binaryen release into `mops.toml` on the next build/bench (rewrites the file like `mops add` — prefer pinning explicitly in CI).
 
 If `wasm-opt` fails, mops warns and keeps the unoptimized Wasm (same soft-fail behavior as dfx). Use `--verbose` for full `wasm-opt` output.
 

--- a/docs/docs/09-mops.toml.md
+++ b/docs/docs/09-mops.toml.md
@@ -65,6 +65,7 @@ See [toolchain management](/cli/toolchain) page for more details.
 | wasmtime             | WASM runtime version (e.g. `41.0.0`) or file path used to run [tests](/cli/mops-test#--mode) in `wasi` mode   |
 | pocket-ic            | Local IC replica version (e.g. `12.0.0`) or file path used to run [benchmarks](/cli/mops-bench#--replica)   |
 | lintoko              | Linter version (e.g. `0.7.0`) or file path for Motoko linting   |
+| wasm-opt             | Binaryen version (e.g. `131`) or file path used for `[optimize]` post-build Wasm optimization   |
 
 File paths must start with `/`, `./`, or `../`.
 
@@ -194,6 +195,38 @@ args = ["--release", "--ai-errors"]
 ```
 
 These flags are applied after `[moc].args` and before per-canister `[canisters.<name>].args`.
+
+
+## [optimize]
+
+Opt-in post-build Wasm optimization via Binaryen's `wasm-opt`. When this section is present (even empty), `mops build` and `mops bench` run `wasm-opt` on the compiled module after candid metadata is attached.
+
+| Field       | Description |
+| ----------- | ----------- |
+| level       | Optimization level: `O0`, `O1`, `O2`, `O3` (default), `O4`, `Os`, or `Oz` |
+| keep-names  | Keep the Wasm name section for readable backtraces (default `true`, maps to `wasm-opt -g`) |
+| args        | Extra flags passed to `wasm-opt` (optional) |
+
+Example — enable with defaults (`O3`, keep names):
+```toml
+[optimize]
+```
+
+Example — size-oriented, strip names, extra flag:
+```toml
+[optimize]
+level = "Oz"
+keep-names = false
+args = ["--enable-bulk-memory"]
+```
+
+Pin Binaryen via `[toolchain] wasm-opt` (e.g. `"131"`). If `[optimize]` is set and `wasm-opt` is not pinned, mops auto-pins the latest Binaryen release into `mops.toml` on the next build/bench.
+
+If `wasm-opt` fails, mops warns and keeps the unoptimized Wasm (same soft-fail behavior as dfx). Use `--verbose` for full `wasm-opt` output.
+
+:::note
+Deploy recipes (e.g. icp-cli) that also run `wasm-opt` should skip that step when mops already optimized the artifact — avoid stacking passes. Actor-class Wasm embedded inside Motoko modules is not recursively optimized.
+:::
 
 
 ## [deployed]

--- a/docs/docs/cli/4-dev/02-mops-bench.md
+++ b/docs/docs/cli/4-dev/02-mops-bench.md
@@ -30,12 +30,14 @@ Under the hood, Mops will:
 
 The number you get is for the exact wasm the chosen replica runs, and the two replicas install it differently:
 
-- **`pocket-ic`** runs the raw `moc` output — **no optimization**.
-- **`dfx`** post-optimizes the module before installing it (`optimize: "cycles"`, via `ic-wasm`), so its instruction counts can be meaningfully lower.
+- **With [`[optimize]`](/mops.toml#optimize)** — `mops bench` runs `wasm-opt` on the module before deploy (same pass as `mops build`). Prefer this when you want bench numbers to match an optimized deploy artifact. When `[optimize]` is set, the deprecated `dfx` replica path does **not** apply a second `optimize: "cycles"` pass.
+- **Without `[optimize]`**:
+  - **`pocket-ic`** runs the raw `moc` output — **no optimization**.
+  - **`dfx`** post-optimizes before install (`optimize: "cycles"`, via `ic-wasm`), so instruction counts can be lower — and that path fails on EOP Motoko (Table64), falling back to unoptimized Wasm.
 
-The same benchmark can therefore report different numbers across replicas. Always compare runs made with the **same replica**.
+Always compare runs made with the **same replica** and the same `[optimize]` settings.
 
-Also note that `dfx`'s optimization is best-effort: if it fails (for example, on wasm modules using features the bundled `ic-wasm` can't process, such as multi-value), `dfx` prints `WARNING: Failed to optimize the Wasm module` and falls back to the **unoptimized** module. Run with [`--verbose`](#--verbose) to see this warning.
+If `wasm-opt` fails, mops warns and keeps the unoptimized module. Run with [`--verbose`](#--verbose) for details.
 
 :::
 

--- a/docs/docs/cli/4-dev/02-mops-bench.md
+++ b/docs/docs/cli/4-dev/02-mops-bench.md
@@ -30,7 +30,7 @@ Under the hood, Mops will:
 
 The number you get is for the exact wasm the chosen replica runs, and the two replicas install it differently:
 
-- **With [`[optimize]`](/mops.toml#optimize)** — `mops bench` runs `wasm-opt` on the module before deploy (same pass as `mops build`). Prefer this when you want bench numbers to match an optimized deploy artifact. When `[optimize]` is set, the deprecated `dfx` replica path does **not** apply a second `optimize: "cycles"` pass.
+- **With [`[optimize]`](/mops.toml#optimize)** — `mops bench` runs `wasm-opt` on the module before deploy (same pass as `mops build`). Prefer this when you want bench numbers to match an optimized deploy artifact. When that pass **succeeds**, the deprecated `dfx` replica path does **not** apply a second `optimize: "cycles"` pass (on soft-fail, dfx still may).
 - **Without `[optimize]`**:
   - **`pocket-ic`** runs the raw `moc` output — **no optimization**.
   - **`dfx`** post-optimizes before install (`optimize: "cycles"`, via `ic-wasm`), so instruction counts can be lower — and that path fails on EOP Motoko (Table64), falling back to unoptimized Wasm.

--- a/docs/docs/cli/4-dev/03-mops-build.md
+++ b/docs/docs/cli/4-dev/03-mops-build.md
@@ -23,6 +23,8 @@ For each canister, three files are written to the output directory (default `.mo
 
 If the canister config sets a `candid` field, the generated `.did` is also checked for compatibility against it.
 
+When [`[optimize]`](/mops.toml#optimize) is set in `mops.toml`, mops runs Binaryen `wasm-opt` on the Wasm **after** candid metadata is embedded. Defaults are `-O3 -g` (see the config reference). Failures warn and leave the unoptimized module.
+
 ### Examples
 
 Build all canisters defined in `mops.toml`

--- a/docs/docs/cli/5-toolchain/01-toolchain-overview.md
+++ b/docs/docs/cli/5-toolchain/01-toolchain-overview.md
@@ -14,6 +14,7 @@ When you run `mops install` command, Mops will install the specified version of 
 - `wasmtime` - Wasmtime runtime (used by `mops test --mode wasi`)
 - `pocket-ic` - PocketIC replica (used by `mops bench --replica pocket-ic`)
 - `lintoko` - Extensible linter for Motoko ([https://github.com/caffeinelabs/lintoko](https://github.com/caffeinelabs/lintoko))
+- `wasm-opt` - Binaryen Wasm optimizer (used when [`[optimize]`](/mops.toml#optimize) is set)
 
 ## Specifying tool versions
 
@@ -25,6 +26,7 @@ mops toolchain use moc 0.10.3
 mops toolchain use wasmtime 16.0.0
 mops toolchain use pocket-ic 1.0.0
 mops toolchain use lintoko 0.7.0
+mops toolchain use wasm-opt 131
 ```
 
 No need to run `mops install` when you use `mops toolchain use` command.
@@ -39,6 +41,7 @@ moc = "0.10.3"
 wasmtime = "16.0.0"
 lintoko = "0.7.0"
 pocket-ic = "1.0.0"
+wasm-opt = "131"
 ```
 
 You need to run `mops install` command when you edit `mops.toml` file manually.


### PR DESCRIPTION
## Summary
`mops build` and `mops bench` can run Binaryen `wasm-opt` so bench numbers match an optimized deploy artifact. dfx’s embedded `ic-wasm optimize` path fails on EOP Motoko (Table64) and silently ships raw Wasm — this uses the maintained `wasm-opt` CLI instead.

Related: [LANG-1337](https://linear.app/caffeinelabs/issue/LANG-1337/mops-wasm-optimization-via-wasm-opt-build-bench), [mops#587](https://github.com/caffeinelabs/mops/issues/587).

### Before
```toml
# no optimize support — pocket-ic benches always run raw moc output
```
```
$ mops bench --verbose
  optimize:  none (raw moc output)
```

### After
```toml
[optimize]                 # empty = on; defaults -O3 -g
# level = "O3"
# keep-names = true
# args = []

[toolchain]
wasm-opt = "131"           # auto-pinned to latest if missing when [optimize] is set
```
```
$ mops build
Optimized main.wasm (wasm-opt 131 -O3 -g)
```

If `wasm-opt` fails, mops warns and keeps the unoptimized module (`--verbose` shows details).

## What is unchanged
- Opt-in only — no `[optimize]` means no pass (existing projects unchanged).
- No `--no-optimize` CLI flag, per-canister overrides, or `cycles`/`size` aliases (follow-ups on LANG-1337).
- Actor-class embedded Wasm is not recursively optimized; document that deploy recipes should not double-run `wasm-opt` when consuming mops artifacts.


Made with [Cursor](https://cursor.com)