### PR TITLE
feat(cli): add `--no-optimize` flag to build and bench

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -122,7 +122,7 @@ mops build -- --ai-errors # pass extra moc flags
 
 Produces `.wasm`, `.did`, and `.most` files in `[build].outputDir` (default `.mops/.build`).
 
-With `[optimize]` in `mops.toml`, runs `wasm-opt` after candid metadata (default `-O3 -g`). Pin Binaryen with `mops toolchain use wasm-opt 131` (or let auto-pin write latest on first build). Soft-fails to unoptimized Wasm on error.
+With `[optimize]` in `mops.toml`, runs `wasm-opt` after candid metadata (default `-O3 -g`). Pin Binaryen with `mops toolchain use wasm-opt 131` (or let auto-pin write latest on first build). Soft-fails to unoptimized Wasm on error. Pass `--no-optimize` (on `build` or `bench`) to skip the pass for a single run without editing `mops.toml`.
 
 ### `mops deployed`
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - `[optimize]` runs Binaryen `wasm-opt` after `mops build` / `mops bench` (opt-in). Empty `[optimize]` defaults to `-O3 -g`. Pin via `[toolchain] wasm-opt` (Binaryen version, e.g. `131`); auto-pins latest if missing. Soft-fails to unoptimized Wasm on error.
+- `mops build` and `mops bench` accept `--no-optimize` to skip the `[optimize]` `wasm-opt` post-pass for a single run without editing `mops.toml` (no-op when `[optimize]` is not set).
 
 ## 2.18.0
 

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -340,6 +340,12 @@ program
   .description("Build a canister")
   .addOption(new Option("--verbose", "Verbose console output"))
   .addOption(new Option("--output, -o <output>", "Output directory"))
+  .addOption(
+    new Option(
+      "--no-optimize",
+      "Skip the [optimize] wasm-opt post-pass even when it is configured in mops.toml",
+    ),
+  )
   .addHelpText(
     "after",
     "\nArguments after -- are forwarded directly to moc, e.g.:\n  $ mops build -- -Werror",
@@ -584,6 +590,12 @@ program
     new Option(
       "--verbose",
       "Print the benchmark pipeline (compiler, replica, GC, context, persistence, profile, optimization) and stream compiler/replica output, including dfx optimization warnings",
+    ),
+  )
+  .addOption(
+    new Option(
+      "--no-optimize",
+      "Skip the [optimize] wasm-opt post-pass even when it is configured in mops.toml",
     ),
   )
   .addHelpText(

--- a/cli/commands/bench.ts
+++ b/cli/commands/bench.ts
@@ -51,6 +51,8 @@ type BenchOptions = {
   verbose: boolean;
   silent: boolean;
   profile: "Debug" | "Release";
+  /** `false` skips the `[optimize]` wasm-opt pass (`--no-optimize`). */
+  optimize: boolean;
   extraArgs: string[];
 };
 
@@ -75,6 +77,7 @@ export async function bench(
     verbose: false,
     silent: false,
     profile: dfxJson?.profile || "Release",
+    optimize: true,
     extraArgs: [],
   };
 
@@ -112,9 +115,12 @@ export async function bench(
   warnIfDfxReplica(replicaType, optionsArg.replica === "dfx");
 
   if (options.verbose) {
-    // Without [optimize], dfx still post-optimizes on deploy; pocket-ic runs raw moc output.
-    let optimize = formatOptimizePipeline(config);
-    if (optimize === "none (raw moc output)") {
+    // With no mops pass (no [optimize] or --no-optimize), dfx still post-optimizes
+    // on deploy; pocket-ic runs raw moc output.
+    let optimize = formatOptimizePipeline(config, {
+      optimize: options.optimize,
+    });
+    if (optimize.startsWith("none")) {
       optimize =
         replicaType === "dfx" || replicaType === "dfx-pocket-ic"
           ? 'dfx `optimize: "cycles"` (ic-wasm) on deploy'
@@ -388,6 +394,7 @@ async function deployBenchFile(
   let wasm = path.join(tempDir, "canister.wasm");
   let optimized = await optimizeWasm(wasm, readConfig(), {
     verbose: options.verbose,
+    optimize: options.optimize,
   });
   fs.writeFileSync(
     path.join(tempDir, "dfx.json"),

--- a/cli/commands/build.ts
+++ b/cli/commands/build.ts
@@ -20,6 +20,8 @@ import { toolchain } from "./toolchain/index.js";
 export interface BuildOptions {
   outputDir: string;
   verbose: boolean;
+  /** `false` skips the `[optimize]` wasm-opt pass (`--no-optimize`). */
+  optimize: boolean;
   extraArgs: string[];
 }
 
@@ -201,7 +203,10 @@ export async function build(
           customSections,
         );
         await writeFile(wasmPath, newWasm);
-        await optimizeWasm(wasmPath, config, { verbose: options.verbose });
+        await optimizeWasm(wasmPath, config, {
+          verbose: options.verbose,
+          optimize: options.optimize,
+        });
       } catch (err: any) {
         if (err.message?.includes("Build failed for canister")) {
           throw err;

--- a/cli/helpers/optimize-config.ts
+++ b/cli/helpers/optimize-config.ts
@@ -36,7 +36,13 @@ export function resolveOptimizeConfig(config: Config): OptimizeResolved | null {
 }
 
 /** Describe the active optimize settings for bench/build verbose output. */
-export function formatOptimizePipeline(config: Config): string {
+export function formatOptimizePipeline(
+  config: Config,
+  { optimize }: { optimize?: boolean } = {},
+): string {
+  if (optimize === false) {
+    return "none (--no-optimize)";
+  }
   let resolved = resolveOptimizeConfig(config);
   if (!resolved) {
     return "none (raw moc output)";

--- a/cli/helpers/optimize-wasm.ts
+++ b/cli/helpers/optimize-wasm.ts
@@ -59,6 +59,8 @@ export async function ensureWasmOptPinned(
 
 export type OptimizeWasmOptions = {
   verbose?: boolean;
+  /** `false` force-disables the pass (e.g. `--no-optimize`), even if `[optimize]` is set. */
+  optimize?: boolean;
 };
 
 /**
@@ -70,6 +72,9 @@ export async function optimizeWasm(
   config: Config = readConfig(),
   options: OptimizeWasmOptions = {},
 ): Promise<boolean> {
+  if (options.optimize === false) {
+    return false;
+  }
   let resolved = resolveOptimizeConfigOrExit(config);
   if (!resolved) {
     return false;

--- a/cli/tests/build.test.ts
+++ b/cli/tests/build.test.ts
@@ -156,6 +156,23 @@ describe("build", () => {
     }
   });
 
+  test("--no-optimize skips the wasm-opt pass", async () => {
+    const cwd = path.join(import.meta.dirname, "build/optimize");
+    const stamp = path.join(cwd, ".mops/.build/.wasm-opt-ran");
+    try {
+      const result = await cli(["build", "--no-optimize", "--verbose"], {
+        cwd,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).not.toMatch(/Optimized main\.wasm/);
+      expect(existsSync(path.join(cwd, ".mops/.build/main.wasm"))).toBe(true);
+      expect(existsSync(stamp)).toBe(false);
+    } finally {
+      cleanFixture(cwd);
+      rmSync(stamp, { force: true });
+    }
+  });
+
   test("[optimize] soft-fails when wasm-opt errors", async () => {
     const cwd = path.join(import.meta.dirname, "build/optimize-fail");
     try {

--- a/cli/tests/optimize-wasm.test.ts
+++ b/cli/tests/optimize-wasm.test.ts
@@ -59,6 +59,15 @@ describe("optimize-config", () => {
     ).toBe("wasm-opt 131 -Oz");
   });
 
+  test("formatOptimizePipeline: --no-optimize overrides an enabled config", () => {
+    expect(
+      formatOptimizePipeline(
+        { optimize: {}, toolchain: { "wasm-opt": "131" } } as Config,
+        { optimize: false },
+      ),
+    ).toBe("none (--no-optimize)");
+  });
+
   test("normalizeBinaryenVersion", () => {
     expect(normalizeBinaryenVersion("version_131")).toBe("131");
     expect(normalizeBinaryenVersion("ersion_131")).toBe("131");

--- a/docs/docs/09-mops.toml.md
+++ b/docs/docs/09-mops.toml.md
@@ -224,6 +224,8 @@ Pin Binaryen via `[toolchain] wasm-opt` (e.g. `"131"`). If `[optimize]` is set a
 
 If `wasm-opt` fails, mops warns and keeps the unoptimized Wasm (same soft-fail behavior as dfx). Use `--verbose` for full `wasm-opt` output.
 
+Pass `--no-optimize` to [`mops build`](/cli/mops-build#--no-optimize) or [`mops bench`](/cli/mops-bench#--no-optimize) to skip this pass for a single run without editing `mops.toml`.
+
 :::note
 Deploy recipes (e.g. icp-cli) that also run `wasm-opt` should skip that step when mops already optimized the artifact — avoid stacking passes. Actor-class Wasm embedded inside Motoko modules is not recursively optimized.
 :::

--- a/docs/docs/cli/4-dev/02-mops-bench.md
+++ b/docs/docs/cli/4-dev/02-mops-bench.md
@@ -30,7 +30,7 @@ Under the hood, Mops will:
 
 The number you get is for the exact wasm the chosen replica runs, and the two replicas install it differently:
 
-- **With [`[optimize]`](/mops.toml#optimize)** — `mops bench` runs `wasm-opt` on the module before deploy (same pass as `mops build`). Prefer this when you want bench numbers to match an optimized deploy artifact. When that pass **succeeds**, the deprecated `dfx` replica path does **not** apply a second `optimize: "cycles"` pass (on soft-fail, dfx still may).
+- **With [`[optimize]`](/mops.toml#optimize)** — `mops bench` runs `wasm-opt` on the module before deploy (same pass as `mops build`). Prefer this when you want bench numbers to match an optimized deploy artifact. When that pass **succeeds**, the deprecated `dfx` replica path does **not** apply a second `optimize: "cycles"` pass (on soft-fail, dfx still may). Pass [`--no-optimize`](#--no-optimize) to skip the `wasm-opt` pass for a single run without editing `mops.toml`.
 - **Without `[optimize]`**:
   - **`pocket-ic`** runs the raw `moc` output — **no optimization**.
   - **`dfx`** post-optimizes before install (`optimize: "cycles"`, via `ic-wasm`), so instruction counts can be lower — and that path fails on EOP Motoko (Table64), falling back to unoptimized Wasm.
@@ -86,6 +86,14 @@ Only works for benchmarks whose runner is **synchronous** — a runner that perf
 Compile benchmark canisters under legacy persistence instead of enhanced orthogonal persistence (the default).
 
 Use it to measure a canister that still uses legacy persistence. Has no effect with `moc < 0.15`, where legacy persistence is already the default.
+
+### `--no-optimize`
+
+Skip the [`[optimize]`](/mops.toml#optimize) `wasm-opt` pass for this run, even when it is configured in `mops.toml`. Has no effect when `[optimize]` is not set. The `dfx` replica may still apply its own `optimize: "cycles"` pass on deploy — only the `pocket-ic` replica then runs the raw `moc` output.
+
+```
+mops bench --no-optimize
+```
 
 ### `--verbose`
 

--- a/docs/docs/cli/4-dev/03-mops-build.md
+++ b/docs/docs/cli/4-dev/03-mops-build.md
@@ -23,7 +23,7 @@ For each canister, three files are written to the output directory (default `.mo
 
 If the canister config sets a `candid` field, the generated `.did` is also checked for compatibility against it.
 
-When [`[optimize]`](/mops.toml#optimize) is set in `mops.toml`, mops runs Binaryen `wasm-opt` on the Wasm **after** candid metadata is embedded. Defaults are `-O3 -g` (see the config reference). Failures warn and leave the unoptimized module.
+When [`[optimize]`](/mops.toml#optimize) is set in `mops.toml`, mops runs Binaryen `wasm-opt` on the Wasm **after** candid metadata is embedded. Defaults are `-O3 -g` (see the config reference). Failures warn and leave the unoptimized module. Pass [`--no-optimize`](#--no-optimize) to skip this pass for a single run.
 
 ### Examples
 
@@ -66,6 +66,14 @@ Default `.mops/.build`
 
 ```
 mops build --output ./dist
+```
+
+### `--no-optimize`
+
+Skip the [`[optimize]`](/mops.toml#optimize) `wasm-opt` post-pass for this run, even when it is configured in `mops.toml`. Has no effect when `[optimize]` is not set. Useful for a faster build or to produce an unoptimized module for debugging without editing `mops.toml`.
+
+```
+mops build --no-optimize
 ```
 
 ## Configuration


### PR DESCRIPTION
`mops build` and `mops bench` now take `--no-optimize` to skip the `[optimize]` `wasm-opt` post-pass for a single run, without touching `mops.toml`. Handy for a faster build or an unoptimized module to debug against, while keeping optimization on by default for everyone else on the project.

### Before
Disabling the pass meant editing `mops.toml` (and remembering to revert it):
```
$ mops build
build canister main
Optimized main.wasm (wasm-opt 131 -O3 -g)
```

### After
```
$ mops build --no-optimize
build canister main
✓ Built 1 canister successfully
```
Under `mops bench --verbose` the pipeline reports the pass as off:
```
$ mops bench --no-optimize --verbose
Benchmark pipeline:
  ...
  optimize:  none (--no-optimize)
```

No-op when `[optimize]` is not set. Skipping the pass also skips wasm-opt auto-pinning, so `--no-optimize` never rewrites `mops.toml`.

The deprecated `dfx` bench replica still applies its own `optimize: "cycles"` pass on deploy — `--no-optimize` only governs the mops pass, so the verbose output keeps flagging the dfx pass for `dfx`/`dfx-pocket-ic`.

Follow-up to [#623](https://github.com/caffeinelabs/mops/pull/623), which shipped `[optimize]` and deferred this flag to LANG-1337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)