### PR TITLE
fix(cli): accept PKCS#8 pem identities in `mops user import`

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- `mops user import` accepts identities in PKCS#8 format (`-----BEGIN PRIVATE KEY-----`, e.g. exported by icp-cli) in addition to the dfx-style SEC1 format, and validates the pem data at import time
+
 ## 2.19.0
 
 - `[optimize]` runs Binaryen `wasm-opt` after `mops build` / `mops bench` (opt-in). Empty `[optimize]` defaults to `-O3 -g`. Pin via `[toolchain] wasm-opt` (Binaryen version, e.g. `131`); auto-pins latest if missing. Soft-fails to unoptimized Wasm on error.

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -645,8 +645,9 @@ userCommand
     new Option("--no-encrypt", "Do not ask for a password to encrypt identity"),
   )
   .action(async (data, options) => {
-    await importPem(data, options);
-    await getPrincipal();
+    if (await importPem(data, options)) {
+      await getPrincipal();
+    }
   });
 
 // user set <prop> <value>

--- a/cli/commands/user.ts
+++ b/cli/commands/user.ts
@@ -7,7 +7,7 @@ import prompts from "prompts";
 import { deleteSync } from "del";
 import { mainActor } from "../api/actors.js";
 import { getIdentity, globalConfigDir } from "../mops.js";
-import { encrypt } from "../pem.js";
+import { decodePem, encrypt } from "../pem.js";
 
 export async function getUserProp(prop: string) {
   let actor = await mainActor();
@@ -56,6 +56,9 @@ export async function importPem(
   options: ImportIdentityOptions = { encrypt: true },
 ) {
   try {
+    // fail early on unsupported keys instead of at first use
+    decodePem(data);
+
     if (!fs.existsSync(globalConfigDir)) {
       fs.mkdirSync(globalConfigDir);
     }
@@ -103,6 +106,8 @@ export async function importPem(
     }
     console.log(chalk.green("Success"));
   } catch (err) {
-    console.log(chalk.red("Error: ") + err);
+    console.log(
+      chalk.red("Error: ") + (err instanceof Error ? err.message : err),
+    );
   }
 }

--- a/cli/commands/user.ts
+++ b/cli/commands/user.ts
@@ -54,7 +54,7 @@ type ImportIdentityOptions = {
 export async function importPem(
   data: string,
   options: ImportIdentityOptions = { encrypt: true },
-) {
+): Promise<boolean> {
   try {
     // fail early on unsupported keys instead of at first use
     decodePem(data);
@@ -82,7 +82,7 @@ export async function importPem(
         });
         if (!res.ok) {
           console.log("aborted");
-          return;
+          return false;
         }
       }
     }
@@ -105,9 +105,12 @@ export async function importPem(
       fs.writeFileSync(identityPem, data);
     }
     console.log(chalk.green("Success"));
+    return true;
   } catch (err) {
     console.log(
       chalk.red("Error: ") + (err instanceof Error ? err.message : err),
     );
+    process.exitCode = 1;
+    return false;
   }
 }

--- a/cli/global.d.ts
+++ b/cli/global.d.ts
@@ -1,3 +1,2 @@
-declare module "pem-file";
 declare module "get-folder-size";
 declare module "decomp-tarxz";

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -37,7 +37,6 @@
         "minimatch": "10.2.5",
         "ncp": "2.0.0",
         "octokit": "3.1.2",
-        "pem-file": "1.0.1",
         "pic-ic": "0.5.4",
         "pic-js-mops": "0.14.8",
         "prettier": "3.5.3",
@@ -11985,12 +11984,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/pem-file": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pem-file/-/pem-file-1.0.1.tgz",
-      "integrity": "sha512-jIDhaSc4Pk8go+kDYJJ2aS7Bg8Lxvir02NnGp9B1bdJpKiDH680ULl+Duh0jBkz8gV3PywEAWz9XNYqLcd6kVg==",
-      "license": "MIT"
     },
     "node_modules/pend": {
       "version": "1.2.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -79,7 +79,6 @@
     "minimatch": "10.2.5",
     "ncp": "2.0.0",
     "octokit": "3.1.2",
-    "pem-file": "1.0.1",
     "pic-ic": "0.5.4",
     "pic-js-mops": "0.14.8",
     "prettier": "3.5.3",

--- a/cli/pem.ts
+++ b/cli/pem.ts
@@ -3,29 +3,41 @@ import { Buffer } from "node:buffer";
 import crypto from "node:crypto";
 import { Ed25519KeyIdentity } from "@icp-sdk/core/identity";
 import { Secp256k1KeyIdentity } from "@icp-sdk/core/identity/secp256k1";
-import pemfile from "pem-file";
 
 export function decodeFile(file: string, password?: string) {
   let rawKey = fs.readFileSync(file);
   if (password) {
-    return decode(decrypt(rawKey, password));
+    return decodePem(decrypt(rawKey, password));
   }
-  return decode(rawKey);
+  return decodePem(rawKey);
 }
 
-function decode(rawKey: Buffer) {
-  let buf: Buffer = pemfile.decode(rawKey);
-  if (rawKey.includes("EC PRIVATE KEY")) {
-    if (buf.length != 118) {
-      throw "expecting byte length 118 but got " + buf.length;
-    }
-    return Secp256k1KeyIdentity.fromSecretKey(buf.subarray(7, 39));
+export function decodePem(rawKey: Buffer | string) {
+  let key: crypto.KeyObject;
+  try {
+    key = crypto.createPrivateKey(rawKey);
+  } catch (err) {
+    throw new Error(
+      "failed to parse PEM data" +
+        (err instanceof Error ? ": " + err.message : ""),
+    );
   }
-  if (buf.length != 85) {
-    throw "expecting byte length 85 but got " + buf.length;
+  let jwk = key.export({ format: "jwk" });
+  if (!jwk.d) {
+    throw new Error("not a private key");
   }
-  let secretKey = Buffer.concat([buf.subarray(16, 48)]);
-  return Ed25519KeyIdentity.fromSecretKey(secretKey);
+  let secretKey = Buffer.from(jwk.d, "base64url");
+  if (key.asymmetricKeyType === "ed25519") {
+    return Ed25519KeyIdentity.fromSecretKey(secretKey);
+  }
+  if (key.asymmetricKeyType === "ec" && jwk.crv === "secp256k1") {
+    return Secp256k1KeyIdentity.fromSecretKey(secretKey);
+  }
+  throw new Error(
+    "unsupported key type '" +
+      (jwk.crv || key.asymmetricKeyType) +
+      "', supported: secp256k1, Ed25519",
+  );
 }
 
 let algorithm = "aes-256-ctr";

--- a/cli/pem.ts
+++ b/cli/pem.ts
@@ -22,7 +22,17 @@ export function decodePem(rawKey: Buffer | string) {
         (err instanceof Error ? ": " + err.message : ""),
     );
   }
-  let jwk = key.export({ format: "jwk" });
+  let jwk: crypto.JsonWebKey;
+  try {
+    jwk = key.export({ format: "jwk" });
+  } catch {
+    // key types JWK can't represent (dsa, dh, exotic ec curves)
+    throw new Error(
+      "unsupported key type '" +
+        key.asymmetricKeyType +
+        "', supported: secp256k1, Ed25519",
+    );
+  }
   if (!jwk.d) {
     throw new Error("not a private key");
   }

--- a/cli/tests/pem.test.ts
+++ b/cli/tests/pem.test.ts
@@ -1,0 +1,76 @@
+import crypto from "node:crypto";
+import { describe, expect, test } from "@jest/globals";
+import { decodePem } from "../pem";
+
+// Keys are generated fresh per test run, never persisted, so no key material
+// ever lives in git history (avoids tripping secret scanning on committed pems).
+
+function secp256k1Pair() {
+  let { privateKey } = crypto.generateKeyPairSync("ec", {
+    namedCurve: "secp256k1",
+  });
+  return {
+    sec1: privateKey.export({ type: "sec1", format: "pem" }) as string,
+    pkcs8: privateKey.export({ type: "pkcs8", format: "pem" }) as string,
+  };
+}
+
+// dfx exports Ed25519 as PKCS#8 v2 (embeds the public key); most other
+// tools (openssl, this test's own PKCS#8 export) produce v1. Build v2
+// manually from a v1 key since Node has no direct API for it.
+function ed25519Pair() {
+  let { privateKey } = crypto.generateKeyPairSync("ed25519");
+  let pkcs8V1 = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+
+  let seed = Buffer.from(
+    privateKey.export({ format: "jwk" }).d as string,
+    "base64url",
+  );
+  let pub = crypto
+    .createPublicKey(privateKey)
+    .export({ format: "der", type: "spki" })
+    .subarray(-32);
+  let der = Buffer.concat([
+    Buffer.from("3053020101300506032b657004220420", "hex"),
+    seed,
+    Buffer.from("a123032100", "hex"),
+    pub,
+  ]);
+  let pkcs8V2 =
+    "-----BEGIN PRIVATE KEY-----\n" +
+    der
+      .toString("base64")
+      .match(/.{1,64}/g)!
+      .join("\n") +
+    "\n-----END PRIVATE KEY-----\n";
+
+  return { pkcs8V1, pkcs8V2 };
+}
+
+describe("decodePem", () => {
+  test("decodes dfx-style secp256k1 SEC1 and icp-cli-style PKCS#8 pem to the same identity", () => {
+    let { sec1, pkcs8 } = secp256k1Pair();
+    expect(decodePem(pkcs8).getPrincipal().toText()).toBe(
+      decodePem(sec1).getPrincipal().toText(),
+    );
+  });
+
+  test("decodes Ed25519 PKCS#8 v1 and dfx-style v2 pem to the same identity", () => {
+    let { pkcs8V1, pkcs8V2 } = ed25519Pair();
+    expect(decodePem(pkcs8V2).getPrincipal().toText()).toBe(
+      decodePem(pkcs8V1).getPrincipal().toText(),
+    );
+  });
+
+  test("rejects unsupported curve", () => {
+    let { privateKey } = crypto.generateKeyPairSync("ec", {
+      namedCurve: "prime256v1",
+    });
+    let pem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+    expect(() => decodePem(pem)).toThrow("unsupported key type 'P-256'");
+  });
+
+  test("rejects invalid pem data", () => {
+    expect(() => decodePem("not a pem")).toThrow("failed to parse PEM data");
+  });
+});

--- a/docs/docs/cli/3-user/01-mops-user-import.md
+++ b/docs/docs/cli/3-user/01-mops-user-import.md
@@ -17,6 +17,8 @@ To be able to publish a packages to the `mops` registry, you need to import an i
 This command accepts PEM file contents, not a path to a file.
 :::
 
+Supported keys are secp256k1 and Ed25519, in SEC1 (`-----BEGIN EC PRIVATE KEY-----`) or PKCS#8 (`-----BEGIN PRIVATE KEY-----`) format. This covers identities exported by `dfx` and `icp-cli`.
+
 ### Import identity from DFX
 
 ```

--- a/docs/docs/cli/3-user/01-mops-user-import.md
+++ b/docs/docs/cli/3-user/01-mops-user-import.md
@@ -11,7 +11,7 @@ Import `.pem` file data to use as identity.
 mops user import -- <pem_data>
 ```
 
-To be able to publish a packages to the `mops` registry, you need to import an identity from DFX.
+To be able to publish packages to the `mops` registry, you need to import an identity from DFX.
 
 :::note
 This command accepts PEM file contents, not a path to a file.


### PR DESCRIPTION
Identities exported by icp-cli couldn't be imported into mops — users had to manually convert them with `openssl ec` first. Fixes [#629](https://github.com/caffeinelabs/mops/issues/629).

`decode()` in `cli/pem.ts` only understood two exact byte layouts: a SEC1 `EC PRIVATE KEY` pem of exactly 118 DER bytes (dfx-style secp256k1), and an 85-byte PKCS#8 blob assumed to be Ed25519 with the seed at hardcoded offsets. icp-cli exports secp256k1 keys in PKCS#8 format (`BEGIN PRIVATE KEY`, 135 DER bytes), which fell into the Ed25519 branch and died with a byte-length error. The upstream `Secp256k1KeyIdentity.fromPem` has the same limitation (SEC1-only), so the fix lands here.

`decode()` now parses the pem with Node's built-in `crypto.createPrivateKey`, which handles SEC1 and PKCS#8 (v1 and v2) natively, then picks the identity class from the actual key type. The brittle length checks, hardcoded offsets, and the `pem-file` dependency are gone, and unsupported curves get a real error message. Tests verify that both encodings of the same key produce the same principal, including the exact 85-byte PKCS#8-v2 Ed25519 layout the old code supported.

`mops user import` also validates the pem up front now, so a bad key fails at import time instead of at first use — and no longer wipes the previously imported identity before failing.

**Before:**
```
$ mops user import --no-encrypt -- "$(cat icp-cli.pem)"
Success
Error: expecting byte length 85 but got 135
```

**After:**
```
$ mops user import --no-encrypt -- "$(cat icp-cli.pem)"
Success
sj2j2-4nasz-lxtin-foevv-zcmzk-3oj6a-n7imf-vyuwc-qpnwk-mqoc7-kae

$ mops user import --no-encrypt -- "$(cat p256.pem)"
Error: unsupported key type 'P-256', supported: secp256k1, Ed25519
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)