### PR TITLE
ci: cancel superseded runs and cap job duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    timeout-minutes: 45
     strategy:
       matrix:
         moc-version: [0.14.13]
@@ -104,6 +109,7 @@ jobs:
         run: cd cli && npm test
 
   bundle-smoke-test:
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     name: bundle build smoke test
     steps:
@@ -132,6 +138,7 @@ jobs:
           mops build
 
   ci-ok:
+    timeout-minutes: 5
     if: always()
     needs: [build, bundle-smoke-test]
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-bundle.yml
+++ b/.github/workflows/cli-bundle.yml
@@ -10,8 +10,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    timeout-minutes: 30
     strategy:
       matrix:
         node-version: [22, 24]
@@ -51,6 +56,7 @@ jobs:
       - run: mops format
 
   ci-ok-cli:
+    timeout-minutes: 5
     if: always()
     needs: [build]
     runs-on: ubuntu-latest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,8 +7,13 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -10,8 +10,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
+    timeout-minutes: 45
     strategy:
       max-parallel: 4
       fail-fast: false
@@ -72,6 +77,7 @@ jobs:
         run: mops test
 
   ci-ok-mops:
+    timeout-minutes: 5
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Repeated pushes on the same PR (or branch) were starting a full new CI run while the previous one kept going, so superseded workflows kept burning runner minutes until they finished. Jobs also had no explicit timeout, so they inherited GitHub’s six-hour default if something hung (replica, Jest, network).

Each PR/push workflow now uses `concurrency` with `cancel-in-progress: true` (same idea as `ai-pr-review.yml`), grouped by PR number or ref. Heavy jobs get `timeout-minutes` with headroom over normal run times (45m for full CI / mops test, 30m bundle matrix, 15m lint, 5m aggregate gates).

## What is unchanged

`release.yml` still uses `cancel-in-progress: false` so release runs are not cancelled mid-flight.


Made with [Cursor](https://cursor.com)