### PR TITLE
chore(cli): remove inaccurate Node 26 crash changelog entry

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Next
 
 - `mops user import` accepts identities in PKCS#8 format (`-----BEGIN PRIVATE KEY-----`, e.g. exported by icp-cli) in addition to the dfx-style SEC1 format, and validates the pem data at import time
-- Fix every `mops` command crashing on startup on Node.js 26 (GH #628) by bumping `octokit` `3.1.2` → `4.1.4`, which drops a transitive dependency incompatible with Node 26.
 
 ## 2.19.0
 


### PR DESCRIPTION
#630’s `octokit` upgrade remains; we dropped the `## Next` bullet that claimed every `mops` command crashed on startup on Node.js 26. We couldn’t reproduce that failure before or after the bump.

Follow-up to [#630](https://github.com/dfinity/mops/pull/630) / GH #628.

Made with [Cursor](https://cursor.com)