### PR TITLE
fix(cli): derive identity encryption key with scrypt and a random salt

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Strengthen encryption of password-protected identities (`mops user import` with a password): the key is now derived with scrypt and a random per-file salt, and the file is encrypted with authenticated AES-256-GCM (previously an unsalted SHA-256 of the password with AES-256-CTR). Existing encrypted identity files are transparently re-encrypted in the new format on next successful use.
+
 - Fix every `mops` command crashing on startup on Node.js 26 (GH #628) by bumping `octokit` `3.1.2` → `4.1.4`, which drops a transitive dependency incompatible with Node 26.
 
 ## 2.19.0

--- a/cli/pem.ts
+++ b/cli/pem.ts
@@ -8,7 +8,15 @@ import pemfile from "pem-file";
 export function decodeFile(file: string, password?: string) {
   let rawKey = fs.readFileSync(file);
   if (password) {
-    return decode(decrypt(rawKey, password));
+    let decrypted = decrypt(rawKey, password);
+    let identity = decode(decrypted);
+    if (!hasMagic(rawKey)) {
+      // legacy sha-256/ctr file; re-encrypt with the current format (best-effort)
+      try {
+        fs.writeFileSync(file, encrypt(decrypted, password));
+      } catch {}
+    }
+    return identity;
   }
   return decode(rawKey);
 }
@@ -28,36 +36,64 @@ function decode(rawKey: Buffer) {
   return Ed25519KeyIdentity.fromSecretKey(secretKey);
 }
 
-let algorithm = "aes-256-ctr";
+// v1 file layout: magic | 16-byte salt | 12-byte iv | 16-byte gcm auth tag | ciphertext.
+// Files without the magic header use the legacy scheme: 16-byte iv | aes-256-ctr ciphertext
+// with the key derived from an unsalted sha-256 of the password (fast to brute-force,
+// so kept for decryption only).
+let magic = Buffer.from("MOPSENCv1");
+let saltLength = 16;
+let ivLength = 12;
+let authTagLength = 16;
+// N=2^17 keeps a single derivation around ~100ms; maxmem must exceed 128 * N * r
+let scryptOptions = { N: 2 ** 17, r: 8, p: 1, maxmem: 256 * 1024 * 1024 };
 
-export function encrypt(buffer: Buffer, password: string) {
-  let key = crypto
-    .createHash("sha256")
-    .update(password)
-    .digest("base64")
-    .slice(0, 32);
-  // Create an initialization vector
-  let iv = crypto.randomBytes(16);
-  // Create a new cipher using the algorithm, key, and iv
-  let cipher = crypto.createCipheriv(algorithm, key, iv);
-  // Create the new (encrypted) buffer
-  let result = Buffer.concat([iv, cipher.update(buffer), cipher.final()]);
-  return result;
+function hasMagic(buffer: Buffer): boolean {
+  return buffer.subarray(0, magic.length).equals(magic);
 }
 
-function decrypt(encrypted: Buffer, password: string) {
+function deriveKey(password: string, salt: Buffer): Buffer {
+  return crypto.scryptSync(password, salt, 32, scryptOptions);
+}
+
+export function encrypt(buffer: Buffer, password: string): Buffer {
+  let salt = crypto.randomBytes(saltLength);
+  let key = deriveKey(password, salt);
+  let iv = crypto.randomBytes(ivLength);
+  let cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  let ciphertext = Buffer.concat([cipher.update(buffer), cipher.final()]);
+  return Buffer.concat([magic, salt, iv, cipher.getAuthTag(), ciphertext]);
+}
+
+export function decrypt(encrypted: Buffer, password: string): Buffer {
+  if (!hasMagic(encrypted)) {
+    return decryptLegacy(encrypted, password);
+  }
+  let saltEnd = magic.length + saltLength;
+  let ivEnd = saltEnd + ivLength;
+  let authTagEnd = ivEnd + authTagLength;
+  let key = deriveKey(password, encrypted.subarray(magic.length, saltEnd));
+  let decipher = crypto.createDecipheriv(
+    "aes-256-gcm",
+    key,
+    encrypted.subarray(saltEnd, ivEnd),
+  );
+  decipher.setAuthTag(encrypted.subarray(ivEnd, authTagEnd));
+  return Buffer.concat([
+    decipher.update(encrypted.subarray(authTagEnd)),
+    decipher.final(),
+  ]);
+}
+
+function decryptLegacy(encrypted: Buffer, password: string) {
   let key = crypto
     .createHash("sha256")
     .update(password)
     .digest("base64")
     .slice(0, 32);
-  // Get the iv: the first 16 bytes
   let iv = encrypted.subarray(0, 16);
-  // Get the rest
-  encrypted = encrypted.subarray(16);
-  // Create a decipher
-  let decipher = crypto.createDecipheriv(algorithm, key, iv);
-  // Actually decrypt it
-  let result = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-  return result;
+  let decipher = crypto.createDecipheriv("aes-256-ctr", key, iv);
+  return Buffer.concat([
+    decipher.update(encrypted.subarray(16)),
+    decipher.final(),
+  ]);
 }

--- a/cli/tests/pem.test.ts
+++ b/cli/tests/pem.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, describe, expect, test } from "@jest/globals";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Buffer } from "node:buffer";
+import { decodeFile, decrypt, encrypt } from "../pem";
+
+// Generated at runtime so no key material is committed to the repo
+const generatePem = (): string => {
+  let { privateKey } = crypto.generateKeyPairSync("ec", {
+    namedCurve: "secp256k1",
+  });
+  return privateKey.export({ type: "sec1", format: "pem" }).toString();
+};
+
+// The pre-scrypt encryption scheme (unsalted sha-256 key, aes-256-ctr, no header)
+const encryptLegacy = (buffer: Buffer, password: string): Buffer => {
+  let key = crypto
+    .createHash("sha256")
+    .update(password)
+    .digest("base64")
+    .slice(0, 32);
+  let iv = crypto.randomBytes(16);
+  let cipher = crypto.createCipheriv("aes-256-ctr", key, iv);
+  return Buffer.concat([iv, cipher.update(buffer), cipher.final()]);
+};
+
+const magic = Buffer.from("MOPSENCv1");
+const hasMagic = (buffer: Buffer) =>
+  buffer.subarray(0, magic.length).equals(magic);
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mops-pem-test-"));
+
+afterAll(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("encrypt/decrypt", () => {
+  test("round-trip restores the original data", () => {
+    let data = crypto.randomBytes(100);
+    let password = crypto.randomBytes(8).toString("hex");
+    expect(decrypt(encrypt(data, password), password).equals(data)).toBe(true);
+  });
+
+  test("encrypted data starts with the format magic header", () => {
+    let encrypted = encrypt(Buffer.from("data"), "password");
+    expect(hasMagic(encrypted)).toBe(true);
+  });
+
+  test("uses a fresh salt and iv for every call", () => {
+    let data = Buffer.from("data");
+    let a = encrypt(data, "password");
+    let b = encrypt(data, "password");
+    expect(a.equals(b)).toBe(false);
+  });
+
+  test("wrong password throws", () => {
+    let encrypted = encrypt(Buffer.from("data"), "password");
+    expect(() => decrypt(encrypted, "wrong")).toThrow();
+  });
+
+  test("tampered ciphertext throws", () => {
+    let encrypted = encrypt(Buffer.from("data"), "password");
+    let last = encrypted.length - 1;
+    encrypted.writeUInt8(encrypted.readUInt8(last) ^ 0xff, last);
+    expect(() => decrypt(encrypted, "password")).toThrow();
+  });
+
+  test("decrypts legacy sha-256/ctr files", () => {
+    let data = crypto.randomBytes(100);
+    let password = crypto.randomBytes(8).toString("hex");
+    expect(decrypt(encryptLegacy(data, password), password).equals(data)).toBe(
+      true,
+    );
+  });
+});
+
+describe("decodeFile", () => {
+  test("decodes an encrypted pem file", () => {
+    let pem = generatePem();
+    let password = crypto.randomBytes(8).toString("hex");
+    let file = path.join(tempDir, "identity.pem.encrypted");
+    fs.writeFileSync(file, encrypt(Buffer.from(pem), password));
+
+    let identity = decodeFile(file, password);
+    expect(identity.getPrincipal().toText()).toBeTruthy();
+  });
+
+  test("upgrades legacy files to the current format on successful decode", () => {
+    let pem = generatePem();
+    let password = crypto.randomBytes(8).toString("hex");
+    let file = path.join(tempDir, "legacy.pem.encrypted");
+    fs.writeFileSync(file, encryptLegacy(Buffer.from(pem), password));
+
+    let identity = decodeFile(file, password);
+    let upgraded = fs.readFileSync(file);
+    expect(hasMagic(upgraded)).toBe(true);
+
+    // still decodes after the upgrade, to the same identity
+    let identityAfter = decodeFile(file, password);
+    expect(identityAfter.getPrincipal().toText()).toBe(
+      identity.getPrincipal().toText(),
+    );
+  });
+
+  test("wrong password on a legacy file throws and leaves the file untouched", () => {
+    let pem = generatePem();
+    let file = path.join(tempDir, "legacy-wrong.pem.encrypted");
+    let original = encryptLegacy(Buffer.from(pem), "password");
+    fs.writeFileSync(file, original);
+
+    expect(() => decodeFile(file, "wrong")).toThrow();
+    expect(fs.readFileSync(file).equals(original)).toBe(true);
+  });
+});


### PR DESCRIPTION
Password-protected identities (`mops user import` with a password) were encrypted with AES-256-CTR under a key derived as an unsalted, single-round SHA-256 of the password, truncated to 32 base64 characters (192 bits of key material). If `identity.pem.encrypted` leaks, this allows fast offline brute-force — one cheap hash per guess, and rainbow tables apply since there is no salt. Flagged by CodeQL as [`js/insufficient-password-hash`](https://github.com/caffeinelabs/mops/security/code-scanning/11) (high severity).

Encrypted identity files are now versioned with a `MOPSENCv1` magic header. New-format files derive the key with `scrypt` (random 16-byte per-file salt, N=2^17, ~100ms per derivation) and encrypt with AES-256-GCM, so tampering and wrong passwords are detected by authentication rather than by failing to parse the decrypted PEM.

## Compatibility

Headerless files are decrypted with the legacy scheme and transparently re-encrypted in the new format after a successful decode (best-effort — a read-only file keeps working, just unupgraded). Legacy collision with the magic header is not a concern: legacy files start with a random 16-byte IV, so a 9-byte match has probability 2^-72.

No CLI surface changes; `--help` and docs don't describe the on-disk format, so no doc updates beyond the changelog.

Verified end-to-end via the real CLI against a scratch `XDG_CONFIG_HOME`: import → file starts with `MOPSENCv1`; correct password → principal; wrong password → `Error: Invalid password`; a legacy-encrypted file decodes to the same principal and is upgraded in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)