### PR TITLE
release: CLI v2.19.1

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+## 2.19.1
+
 - `mops user import` accepts identities in PKCS#8 format (`-----BEGIN PRIVATE KEY-----`, e.g. exported by icp-cli) in addition to the dfx-style SEC1 format, and validates the pem data at import time
 
 ## 2.19.0

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ic-mops",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ic-mops",
-      "version": "2.19.0",
+      "version": "2.19.1",
       "license": "MIT",
       "dependencies": {
         "@icp-sdk/core": "4.0.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-mops",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "type": "module",
   "bin": {
     "mops": "dist/bin/mops.js",


### PR DESCRIPTION
## Summary
- Release CLI v2.19.1 (patch): PKCS#8 identity import for `mops user import`.

## Test plan
- [ ] Release PR workflow validates changelog and version
- [ ] Post-merge: npm publish and GitHub release


Made with [Cursor](https://cursor.com)