### PR TITLE
fix(cli): store local path deps as root-relative in mops.lock

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -81,7 +81,7 @@ mops install --lock update   # regenerate a stale/corrupt mops.lock
 mops install --lock check    # fail if lockfile is missing or stale (CI)
 ```
 
-Run after cloning or after manual `mops.toml` edits. Updates `mops.lock` by default.
+Run after cloning or after manual `mops.toml` edits. Updates `mops.lock` by default. Local path dependencies are stored root-relative in the lockfile (portable across machines); regenerate with `--lock update` if an older lock still has absolute paths.
 
 When the `CI` env var is set and `--lock` is omitted, defaults to `--lock check` (deprecated — pass `--lock check` explicitly; auto-detection will be removed in v3). A stale lock fails with a hint to run `mops install --lock update`.
 

--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -81,7 +81,7 @@ mops install --lock update   # regenerate a stale/corrupt mops.lock
 mops install --lock check    # fail if lockfile is missing or stale (CI)
 ```
 
-Run after cloning or after manual `mops.toml` edits. Updates `mops.lock` by default. Local path dependencies are stored root-relative in the lockfile (portable across machines); regenerate with `--lock update` if an older lock still has absolute paths.
+Run after cloning or after manual `mops.toml` edits. Updates `mops.lock` by default. Local path dependencies are stored root-relative in the lockfile (portable across machines). A plain install will not rewrite absolute paths left by older CLIs — use `mops install --lock update`, and ensure every environment has a CLI that understands relative lock paths.
 
 When the `CI` env var is set and `--lock` is omitted, defaults to `--lock check` (deprecated — pass `--lock check` explicitly; auto-detection will be removed in v3). A stale lock fails with a hint to run `mops install --lock update`.
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Fix local path dependencies being written into `mops.lock` as absolute filesystem paths, which made committed lockfiles non-portable across machines. Local deps are now stored root-relative (e.g. `./packages/shared`, `../lib`). Regenerate an existing lock with `mops install --lock update`.
+- Fix local path dependencies being written into `mops.lock` as absolute filesystem paths, which made committed lockfiles non-portable across machines. Local deps are now stored root-relative (e.g. `./packages/shared`, `../lib`). Regenerate an existing absolute lock with `mops install --lock update` (a plain `mops install` will not rewrite it). After regenerating, all environments need a CLI that includes this fix — older CLIs treat relative lock paths as cwd-relative and break from subdirectories.
 
 ## 2.19.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Fix local path dependencies being written into `mops.lock` as absolute filesystem paths, which made committed lockfiles non-portable across machines. Local deps are now stored root-relative (e.g. `./packages/shared`, `../lib`). Regenerate an existing lock with `mops install --lock update`.
+
 ## 2.19.1
 
 - `mops user import` accepts identities in PKCS#8 format (`-----BEGIN PRIVATE KEY-----`, e.g. exported by icp-cli) in addition to the dfx-style SEC1 format, and validates the pem data at import time

--- a/cli/commands/lint.ts
+++ b/cli/commands/lint.ts
@@ -41,7 +41,7 @@ async function resolveDepRules(
     const depType = getDependencyType(version);
     let pkgDir: string;
     if (depType === "local") {
-      pkgDir = version;
+      pkgDir = path.resolve(rootDir, version);
     } else if (depType === "github") {
       pkgDir = formatGithubDir(name, version);
     } else {

--- a/cli/commands/sources.ts
+++ b/cli/commands/sources.ts
@@ -6,6 +6,7 @@ import {
   formatDir,
   formatGithubDir,
   getDependencyType,
+  getRootDir,
   readConfig,
 } from "../mops.js";
 import { resolvePackages } from "../resolve-packages.js";
@@ -18,6 +19,7 @@ export async function sourcesArgs({
     return [];
   }
 
+  let rootDir = getRootDir();
   let resolvedPackages = await resolvePackages({ conflicts });
 
   // sources
@@ -27,7 +29,7 @@ export async function sourcesArgs({
 
       let pkgDir;
       if (depType === "local") {
-        pkgDir = path.relative(cwd, version);
+        pkgDir = path.relative(cwd, path.resolve(rootDir, version));
       } else if (depType === "github") {
         pkgDir = path.relative(cwd, formatGithubDir(name, version));
       } else if (depType === "mops") {

--- a/cli/helpers/normalize-local-path.ts
+++ b/cli/helpers/normalize-local-path.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 /**
  * Root-relative local dep path that always matches FILE_PATH_REGEX
- * (`./`, `../`, or absolute). Uses posix separators for portable locks.
+ * (`./…` or `../…`). Uses posix separators for portable locks.
  */
 export function normalizeLocalDepPath(
   rootDir: string,

--- a/cli/helpers/normalize-local-path.ts
+++ b/cli/helpers/normalize-local-path.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+
+/**
+ * Root-relative local dep path that always matches FILE_PATH_REGEX
+ * (`./`, `../`, or absolute). Uses posix separators for portable locks.
+ */
+export function normalizeLocalDepPath(
+  rootDir: string,
+  depPath: string,
+): string {
+  let rel = path.relative(rootDir, path.resolve(rootDir, depPath));
+  rel = rel.split(path.sep).join("/");
+  if (rel === "" || rel === ".") {
+    return "./";
+  }
+  if (rel.startsWith("../") || rel.startsWith("./")) {
+    return rel;
+  }
+  return `./${rel}`;
+}

--- a/cli/integrity.ts
+++ b/cli/integrity.ts
@@ -189,7 +189,8 @@ export async function updateLockFile({
     return false;
   }
 
-  let resolvedDeps = await resolvePackages();
+  // skipLock: re-resolve from mops.toml so abs→relative local paths migrate.
+  let resolvedDeps = await resolvePackages({ skipLock: true });
 
   let fileHashes = await getFileHashesFromRegistry();
 

--- a/cli/resolve-packages.ts
+++ b/cli/resolve-packages.ts
@@ -12,16 +12,19 @@ import { VesselConfig, readVesselConfig } from "./vessel.js";
 import { Config, Dependency } from "./types.js";
 import { getDepCacheDir, getDepCacheName } from "./cache.js";
 import { getPackageId } from "./helpers/get-package-id.js";
+import { normalizeLocalDepPath } from "./helpers/normalize-local-path.js";
 import { checkLockFileLight, readLockFile } from "./integrity.js";
 
 export async function resolvePackages({
   conflicts = "ignore" as "warning" | "error" | "ignore",
+  // Bypass a valid lock so `--lock update` can rewrite absolute local paths.
+  skipLock = false,
 } = {}): Promise<Record<string, string>> {
   if (!checkConfigFile()) {
     return {};
   }
 
-  if (checkLockFileLight()) {
+  if (!skipLock && checkLockFileLight()) {
     let lockFileJson = readLockFile();
 
     if (lockFileJson && lockFileJson.version === 3) {
@@ -216,9 +219,11 @@ export async function resolvePackages({
       .map(([name, pkg]) => {
         let version: string;
         if (pkg.path) {
-          version = path
-            .resolve(rootDir, pkg.path)
-            .replaceAll("{MOPS_ENV}", process.env.MOPS_ENV || "local");
+          // Root-relative so mops.lock is portable across machines.
+          version = normalizeLocalDepPath(
+            rootDir,
+            pkg.path.replaceAll("{MOPS_ENV}", process.env.MOPS_ENV || "local"),
+          );
         } else if (pkg.repo) {
           version = pkg.repo;
         } else if (pkg.version) {

--- a/cli/tests/install/local-path-sibling/mops.toml
+++ b/cli/tests/install/local-path-sibling/mops.toml
@@ -1,0 +1,3 @@
+[package]
+name = "sibling"
+version = "0.1.0"

--- a/cli/tests/install/local-path-sibling/src/lib.mo
+++ b/cli/tests/install/local-path-sibling/src/lib.mo
@@ -1,0 +1,1 @@
+module { public let y = 2 };

--- a/cli/tests/install/local-path/mops.toml
+++ b/cli/tests/install/local-path/mops.toml
@@ -1,0 +1,3 @@
+[dependencies]
+shared = "./packages/shared"
+sibling = "../local-path-sibling"

--- a/cli/tests/install/local-path/packages/shared/mops.toml
+++ b/cli/tests/install/local-path/packages/shared/mops.toml
@@ -1,0 +1,3 @@
+[package]
+name = "shared"
+version = "0.1.0"

--- a/cli/tests/install/local-path/packages/shared/src/lib.mo
+++ b/cli/tests/install/local-path/packages/shared/src/lib.mo
@@ -1,0 +1,1 @@
+module { public let x = 1 };

--- a/cli/tests/local-path-lock.test.ts
+++ b/cli/tests/local-path-lock.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "path";
+import { FILE_PATH_REGEX } from "../constants";
+import { normalizeLocalDepPath } from "../helpers/normalize-local-path";
+import { cli } from "./helpers";
+
+describe("normalizeLocalDepPath", () => {
+  const root = "/proj";
+
+  test("prefixes bare in-tree relatives with ./", () => {
+    expect(normalizeLocalDepPath(root, "packages/shared")).toBe(
+      "./packages/shared",
+    );
+    expect(normalizeLocalDepPath(root, "./packages/shared")).toBe(
+      "./packages/shared",
+    );
+  });
+
+  test("keeps parent-relative paths", () => {
+    expect(normalizeLocalDepPath(root, "../lib")).toBe("../lib");
+  });
+
+  test("maps the root itself to ./", () => {
+    expect(normalizeLocalDepPath(root, ".")).toBe("./");
+    expect(normalizeLocalDepPath(root, root)).toBe("./");
+  });
+
+  test("results always match FILE_PATH_REGEX", () => {
+    for (const p of [
+      "packages/shared",
+      "./packages/shared",
+      "../lib",
+      ".",
+      root,
+    ]) {
+      expect(normalizeLocalDepPath(root, p)).toMatch(FILE_PATH_REGEX);
+    }
+  });
+});
+
+describe("portable local path deps in mops.lock", () => {
+  jest.setTimeout(60_000);
+
+  const cwd = path.join(import.meta.dirname, "install/local-path");
+  const lockFile = path.join(cwd, "mops.lock");
+
+  const cleanup = () => {
+    rmSync(lockFile, { force: true });
+    rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
+  };
+
+  const readLockDeps = (): Record<string, string> => {
+    const lock = JSON.parse(readFileSync(lockFile, "utf8"));
+    return lock.deps;
+  };
+
+  test("writes root-relative local paths, not absolute", async () => {
+    cleanup();
+    try {
+      const result = await cli(["install"], { cwd, env: { CI: undefined } });
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(lockFile)).toBe(true);
+
+      const deps = readLockDeps();
+      expect(deps.shared).toBe("./packages/shared");
+      expect(deps.sibling).toBe("../local-path-sibling");
+      expect(deps.shared).not.toMatch(/^\//);
+      expect(deps.sibling).not.toMatch(/^\//);
+      expect(deps.shared).toMatch(FILE_PATH_REGEX);
+      expect(deps.sibling).toMatch(FILE_PATH_REGEX);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("--lock update rewrites absolute local paths to relative", async () => {
+    cleanup();
+    try {
+      const first = await cli(["install"], { cwd, env: { CI: undefined } });
+      expect(first.exitCode).toBe(0);
+
+      const lock = JSON.parse(readFileSync(lockFile, "utf8"));
+      lock.deps.shared = path.resolve(cwd, "packages/shared");
+      lock.deps.sibling = path.resolve(cwd, "../local-path-sibling");
+      writeFileSync(lockFile, JSON.stringify(lock, null, 2));
+
+      const result = await cli(["install", "--lock", "update"], {
+        cwd,
+        env: { CI: undefined },
+      });
+      expect(result.exitCode).toBe(0);
+
+      const deps = readLockDeps();
+      expect(deps.shared).toBe("./packages/shared");
+      expect(deps.sibling).toBe("../local-path-sibling");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("sources from a subdirectory still resolves local deps", async () => {
+    cleanup();
+    try {
+      const install = await cli(["install"], { cwd, env: { CI: undefined } });
+      expect(install.exitCode).toBe(0);
+
+      const nested = path.join(cwd, "nested");
+      const result = await cli(["sources", "--no-install"], {
+        cwd: nested,
+        env: { CI: undefined },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(
+        /--package shared \.\.\/packages\/shared\/src/,
+      );
+      expect(result.stdout).toMatch(
+        /--package sibling \.\.\/\.\.\/local-path-sibling\/src/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/cli/tests/local-path-lock.test.ts
+++ b/cli/tests/local-path-lock.test.ts
@@ -19,6 +19,7 @@ describe("normalizeLocalDepPath", () => {
 
   test("keeps parent-relative paths", () => {
     expect(normalizeLocalDepPath(root, "../lib")).toBe("../lib");
+    expect(normalizeLocalDepPath(root, "..")).toBe("./..");
   });
 
   test("maps the root itself to ./", () => {

--- a/docs/docs/10-mops.lock.md
+++ b/docs/docs/10-mops.lock.md
@@ -44,7 +44,7 @@ _It's only faster when there are no globally cached packages — for example whe
 - All transitive dependencies with the final resolved versions
 - Hash of each file of each dependency (retrieved from the Mops registry canister)
 
-Local path dependencies are stored relative to the project root (e.g. `./packages/shared`, `../lib`) so the lockfile is portable across machines. If an older lock still has absolute paths, regenerate with `mops install --lock update`.
+Local path dependencies are stored relative to the project root (e.g. `./packages/shared`, `../lib`) so the lockfile is portable across machines. A plain `mops install` will not rewrite an older lock that still has absolute paths — run `mops install --lock update` explicitly. `--lock check` also will not flag absolute local paths (it compares the lock to itself when the deps hash matches). After regenerating, use a CLI that includes this fix; older CLIs treat relative lock paths as cwd-relative and break when run from a subdirectory.
 
 ## CI environments
 

--- a/docs/docs/10-mops.lock.md
+++ b/docs/docs/10-mops.lock.md
@@ -44,6 +44,8 @@ _It's only faster when there are no globally cached packages — for example whe
 - All transitive dependencies with the final resolved versions
 - Hash of each file of each dependency (retrieved from the Mops registry canister)
 
+Local path dependencies are stored relative to the project root (e.g. `./packages/shared`, `../lib`) so the lockfile is portable across machines. If an older lock still has absolute paths, regenerate with `mops install --lock update`.
+
 ## CI environments
 
 **Deprecated:** when the `CI` environment variable is set and `--lock` is omitted, `mops install` defaults to `--lock check` and prints a deprecation warning. This auto-detection will be removed in a future release — pass `--lock check` explicitly (and commit `mops.lock`) to keep that behavior.


### PR DESCRIPTION
`mops.lock` was writing local path dependencies as absolute filesystem paths (e.g. `/Users/you/proj/packages/shared`), so a committed lock was only valid on the machine that generated it — regenerating or checking on another machine/CI mismatched.

**Before** (`rm mops.lock && mops i` with `shared = "./packages/shared"`):
```json
"deps": {
  "shared": "/Users/alice/proj/packages/shared"
}
```

**After:**
```json
"deps": {
  "shared": "./packages/shared"
}
```

Local deps are normalized to root-relative forms that still match `FILE_PATH_REGEX` (`./…`, `../…`). `mops sources` / lint rule resolution resolve them via the project root, so running from a subdirectory keeps working.

**Migration:** a plain `mops install` will not rewrite a hash-valid absolute lock — run `mops install --lock update`. After regenerating, every environment needs a CLI with this fix (older CLIs treat relative lock paths as cwd-relative and break from subdirectories).