### PR TITLE
feat(cli): add `mops publish --dry-run`

### DIFF
--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -201,11 +201,11 @@ mops sync                 # add missing / remove unused packages
 
 ```bash
 mops publish              # publish to the registry (runs tests/docs/bench by default)
-mops publish --dry-run    # local packaging checks + file list; no registry contact
+mops publish --dry-run    # local preflight + file list; no network / identity required
 mops publish --no-test --no-docs --no-bench
 ```
 
-`--dry-run` validates `[package]` metadata, dependency shape, required files, extensions, and the 1000-file limit. It does **not** prove registry acceptance (already published, permissions, missing deps). Prefer it before a real publish; still run `mops test` separately for code quality.
+`--dry-run` runs the same local preflight as publish before upload (field lengths, dependency shape, required files, extensions, 1000-file limit). It does **not** run canister config validation (SPDX/semver/name rules) or prove registry acceptance (already published, permissions, missing deps). Prefer it before a real publish; still run `mops test` separately for code quality.
 
 ### `mops test`
 

--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -206,7 +206,7 @@ mops publish --dry-run --no-test --no-docs --no-bench   # packaging checks only
 mops publish --no-test --no-docs --no-bench
 ```
 
-`--dry-run` runs the same local publish pipeline (packaging checks, docs, tests, benchmarks, changelog) and prints the final file list, then stops before identity/upload. `--no-*` flags work as usual. It does **not** run canister config validation (SPDX/semver/name rules) or prove registry acceptance (already published, permissions, missing deps).
+`--dry-run` runs the same local publish pipeline (packaging checks, docs, changelog, tests, benchmarks) and prints the final file list, then stops before identity/upload. `--no-*` flags work as usual. It does **not** run canister config validation (SPDX/semver/name rules) or prove registry acceptance (already published, permissions, missing deps).
 
 ### `mops test`
 

--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -197,6 +197,16 @@ mops sync                 # add missing / remove unused packages
 
 ## Other Commands
 
+### `mops publish`
+
+```bash
+mops publish              # publish to the registry (runs tests/docs/bench by default)
+mops publish --dry-run    # local packaging checks + file list; no registry contact
+mops publish --no-test --no-docs --no-bench
+```
+
+`--dry-run` validates `[package]` metadata, dependency shape, required files, extensions, and the 1000-file limit. It does **not** prove registry acceptance (already published, permissions, missing deps). Prefer it before a real publish; still run `mops test` separately for code quality.
+
 ### `mops test`
 
 Tests live in `test/*.test.mo`:

--- a/.agents/skills/mops-cli/SKILL.md
+++ b/.agents/skills/mops-cli/SKILL.md
@@ -201,11 +201,12 @@ mops sync                 # add missing / remove unused packages
 
 ```bash
 mops publish              # publish to the registry (runs tests/docs/bench by default)
-mops publish --dry-run    # local preflight + file list; no network / identity required
+mops publish --dry-run    # same local steps as publish; no registry contact / identity
+mops publish --dry-run --no-test --no-docs --no-bench   # packaging checks only
 mops publish --no-test --no-docs --no-bench
 ```
 
-`--dry-run` runs the same local preflight as publish before upload (field lengths, dependency shape, required files, extensions, 1000-file limit). It does **not** run canister config validation (SPDX/semver/name rules) or prove registry acceptance (already published, permissions, missing deps). Prefer it before a real publish; still run `mops test` separately for code quality.
+`--dry-run` runs the same local publish pipeline (packaging checks, docs, tests, benchmarks, changelog) and prints the final file list, then stops before identity/upload. `--no-*` flags work as usual. It does **not** run canister config validation (SPDX/semver/name rules) or prove registry acceptance (already published, permissions, missing deps).
 
 ### `mops test`
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- `mops publish --dry-run` validates local packaging rules and prints the file list without contacting the registry or uploading anything. Does not run tests/docs/bench or prove registry acceptance.
+
 ## 2.19.2
 
 - Fix local path dependencies being written into `mops.lock` as absolute filesystem paths, which made committed lockfiles non-portable across machines. Local deps are now stored root-relative (e.g. `./packages/shared`, `../lib`). Regenerate an existing absolute lock with `mops install --lock update` (a plain `mops install` will not rewrite it). After regenerating, all environments need a CLI that includes this fix — older CLIs treat relative lock paths as cwd-relative and break from subdirectories.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- `mops publish --dry-run` runs local preflight checks and prints the file list without contacting the network or uploading anything. Does not run tests/docs/bench, canister config validation, or prove registry acceptance.
+- `mops publish --dry-run` runs the same local publish steps as a real publish (packaging checks, docs, tests, benchmarks, changelog) and prints the final file list, without contacting the registry or uploading. Honors `--no-docs` / `--no-test` / `--no-bench`. Does not run canister config validation or prove registry acceptance.
 - Fix `mops publish` exiting 0 on keyword-length and invalid `package.files` path errors (now exit 1, same as other preflight failures).
 
 ## 2.19.2

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- `mops publish --dry-run` validates local packaging rules and prints the file list without contacting the registry or uploading anything. Does not run tests/docs/bench or prove registry acceptance.
+- `mops publish --dry-run` runs local preflight checks and prints the file list without contacting the network or uploading anything. Does not run tests/docs/bench, canister config validation, or prove registry acceptance.
 
 ## 2.19.2
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - `mops publish --dry-run` runs local preflight checks and prints the file list without contacting the network or uploading anything. Does not run tests/docs/bench, canister config validation, or prove registry acceptance.
+- Fix `mops publish` exiting 0 on keyword-length and invalid `package.files` path errors (now exit 1, same as other preflight failures).
 
 ## 2.19.2
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- `mops publish --dry-run` runs the same local publish steps as a real publish (packaging checks, docs, tests, benchmarks, changelog) and prints the final file list, without contacting the registry or uploading. Honors `--no-docs` / `--no-test` / `--no-bench`. Does not run canister config validation or prove registry acceptance.
+- `mops publish --dry-run` runs the same local publish steps as a real publish (packaging checks, docs, changelog, tests, benchmarks) and prints the final file list, without contacting the registry or uploading. Honors `--no-docs` / `--no-test` / `--no-bench`. Does not run canister config validation or prove registry acceptance.
 - Fix `mops publish` exiting 0 on keyword-length and invalid `package.files` path errors (now exit 1, same as other preflight failures).
 
 ## 2.19.2

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -227,10 +227,19 @@ program
   .option("--no-docs", "Do not generate docs")
   .option("--no-test", "Do not run tests")
   .option("--no-bench", "Do not run benchmarks")
+  .option(
+    "--dry-run",
+    "Validate local packaging rules and list files without publishing",
+  )
   .option("--verbose", "Show more information")
   .action(async (options) => {
     if (!checkConfigFile()) {
       process.exit(1);
+    }
+    // dry-run is local-only — skip registry API compatibility check
+    if (options.dryRun) {
+      await publish(options);
+      return;
     }
     let compatible = await checkApiCompatibility();
     if (compatible) {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -229,7 +229,7 @@ program
   .option("--no-bench", "Do not run benchmarks")
   .option(
     "--dry-run",
-    "Validate local packaging rules and list files without publishing",
+    "Run local publish steps without contacting the registry or uploading",
   )
   .option("--verbose", "Show more information")
   .action(async (options) => {

--- a/cli/commands/publish.ts
+++ b/cli/commands/publish.ts
@@ -74,14 +74,20 @@ export async function publish(
   // desired fields
   for (let key of ["description"]) {
     // @ts-ignore
-    if (!config.package[key] && !process.env.CI && !options.dryRun) {
-      let res = await prompts({
-        type: "confirm",
-        name: "ok",
-        message: `Missing recommended config key "${key}", publish anyway?`,
-      });
-      if (!res.ok) {
-        return;
+    if (!config.package[key]) {
+      if (options.dryRun) {
+        console.log(
+          chalk.yellow("Warning: ") + `Missing recommended config key "${key}"`,
+        );
+      } else if (!process.env.CI) {
+        let res = await prompts({
+          type: "confirm",
+          name: "ok",
+          message: `Missing recommended config key "${key}", publish anyway?`,
+        });
+        if (!res.ok) {
+          return;
+        }
       }
     }
   }
@@ -332,8 +338,8 @@ export async function publish(
 
   if (options.dryRun) {
     console.log(
-      chalk.green("Dry run OK") +
-        ` — packaging checks passed (${files.length} files). Nothing was published.`,
+      chalk.green("Dry-run OK") +
+        ` — local preflight checks passed (${files.length} files). Nothing was published.`,
     );
     return;
   }

--- a/cli/commands/publish.ts
+++ b/cli/commands/publish.ts
@@ -369,10 +369,12 @@ export async function publish(
         .map((file) => "  " + file)
         .join("\n"),
     );
-    fs.rmSync(path.join(rootDir, ".mops/.docs"), {
-      force: true,
-      recursive: true,
-    });
+    if (options.docs) {
+      fs.rmSync(path.join(rootDir, ".mops/.docs"), {
+        force: true,
+        recursive: true,
+      });
+    }
     console.log(
       chalk.green("Dry-run OK") +
         ` — local publish steps passed (${files.length} files). Nothing was published.`,

--- a/cli/commands/publish.ts
+++ b/cli/commands/publish.ts
@@ -260,7 +260,7 @@ export async function publish(
   // generate docs
   let docsFile = path.join(rootDir, ".mops/.docs/docs.tgz");
   let docsCov = 0;
-  if (options.docs && !options.dryRun) {
+  if (options.docs) {
     console.log("Generating documentation...");
     docsCov = await docsCoverage({
       reporter: "silent",
@@ -307,21 +307,10 @@ export async function publish(
     process.exit(1);
   }
 
-  if (options.dryRun) {
-    console.log("Files:");
-    console.log(
-      [...files]
-        .sort()
-        .map((file) => "  " + file)
-        .join("\n"),
-    );
-  }
-
   // parse changelog
   console.log("Parsing CHANGELOG.md...");
   let changelog = parseChangelog(config.package.version);
   if (
-    !options.dryRun &&
     !changelog &&
     config.package.repository?.startsWith("https://github.com/")
   ) {
@@ -334,14 +323,6 @@ export async function publish(
   if (changelog) {
     console.log("Changelog:");
     console.log(chalk.gray(changelog));
-  }
-
-  if (options.dryRun) {
-    console.log(
-      chalk.green("Dry-run OK") +
-        ` — local preflight checks passed (${files.length} files). Nothing was published.`,
-    );
-    return;
   }
 
   // test
@@ -375,6 +356,28 @@ export async function publish(
       console.log(chalk.red("Error: ") + "benchmarks failed");
       process.exit(1);
     }
+  }
+
+  if (options.dryRun) {
+    console.log("Files:");
+    console.log(
+      [...files]
+        .map((file) =>
+          file === docsFile ? path.relative(rootDir, file) : file,
+        )
+        .sort()
+        .map((file) => "  " + file)
+        .join("\n"),
+    );
+    fs.rmSync(path.join(rootDir, ".mops/.docs"), {
+      force: true,
+      recursive: true,
+    });
+    console.log(
+      chalk.green("Dry-run OK") +
+        ` — local publish steps passed (${files.length} files). Nothing was published.`,
+    );
+    return;
   }
 
   // progress

--- a/cli/commands/publish.ts
+++ b/cli/commands/publish.ts
@@ -178,7 +178,7 @@ export async function publish(
     for (let keyword of config.package.keywords) {
       if (keyword.length > 20) {
         console.log(chalk.red("Error: ") + "max keyword length is 20");
-        return;
+        process.exit(1);
       }
     }
   }
@@ -189,7 +189,7 @@ export async function publish(
         console.log(
           chalk.red("Error: ") + "file path cannot start with '/' or '../'",
         );
-        return;
+        process.exit(1);
       }
     }
   }

--- a/cli/commands/publish.ts
+++ b/cli/commands/publish.ts
@@ -36,6 +36,7 @@ export async function publish(
     test?: boolean;
     bench?: boolean;
     verbose?: boolean;
+    dryRun?: boolean;
   } = {},
 ) {
   if (!checkConfigFile()) {
@@ -45,7 +46,11 @@ export async function publish(
   let rootDir = getRootDir();
   let config = readConfig();
 
-  console.log(`Publishing ${config.package?.name}@${config.package?.version}`);
+  console.log(
+    options.dryRun
+      ? `Dry-run ${config.package?.name}@${config.package?.version}`
+      : `Publishing ${config.package?.name}@${config.package?.version}`,
+  );
 
   // required fields
   if (!config.package) {
@@ -69,7 +74,7 @@ export async function publish(
   // desired fields
   for (let key of ["description"]) {
     // @ts-ignore
-    if (!config.package[key] && !process.env.CI) {
+    if (!config.package[key] && !process.env.CI && !options.dryRun) {
       let res = await prompts({
         type: "confirm",
         name: "ok",
@@ -241,7 +246,7 @@ export async function publish(
   files = [...files, ...defaultFiles];
   files = globbySync([...files, ...defaultFiles]);
 
-  if (options.verbose) {
+  if (options.verbose && !options.dryRun) {
     console.log("Files:");
     console.log(files.map((file) => "  " + file).join("\n"));
   }
@@ -249,7 +254,7 @@ export async function publish(
   // generate docs
   let docsFile = path.join(rootDir, ".mops/.docs/docs.tgz");
   let docsCov = 0;
-  if (options.docs) {
+  if (options.docs && !options.dryRun) {
     console.log("Generating documentation...");
     docsCov = await docsCoverage({
       reporter: "silent",
@@ -296,10 +301,21 @@ export async function publish(
     process.exit(1);
   }
 
+  if (options.dryRun) {
+    console.log("Files:");
+    console.log(
+      [...files]
+        .sort()
+        .map((file) => "  " + file)
+        .join("\n"),
+    );
+  }
+
   // parse changelog
   console.log("Parsing CHANGELOG.md...");
   let changelog = parseChangelog(config.package.version);
   if (
+    !options.dryRun &&
     !changelog &&
     config.package.repository?.startsWith("https://github.com/")
   ) {
@@ -312,6 +328,14 @@ export async function publish(
   if (changelog) {
     console.log("Changelog:");
     console.log(chalk.gray(changelog));
+  }
+
+  if (options.dryRun) {
+    console.log(
+      chalk.green("Dry run OK") +
+        ` — packaging checks passed (${files.length} files). Nothing was published.`,
+    );
+    return;
   }
 
   // test

--- a/cli/tests/__snapshots__/publish-dry-run.test.ts.snap
+++ b/cli/tests/__snapshots__/publish-dry-run.test.ts.snap
@@ -14,6 +14,6 @@ Parsing CHANGELOG.md...
 Changelog:
 * Initial release
 
-Dry run OK — packaging checks passed (4 files). Nothing was published.",
+Dry-run OK — local preflight checks passed (4 files). Nothing was published.",
 }
 `;

--- a/cli/tests/__snapshots__/publish-dry-run.test.ts.snap
+++ b/cli/tests/__snapshots__/publish-dry-run.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`publish --dry-run success 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": "Dry-run dry-run-fixture@0.1.0
+Files:
+  LICENSE
+  README.md
+  mops.toml
+  src/lib.mo
+Parsing CHANGELOG.md...
+Changelog:
+* Initial release
+
+Dry run OK — packaging checks passed (4 files). Nothing was published.",
+}
+`;

--- a/cli/tests/__snapshots__/publish-dry-run.test.ts.snap
+++ b/cli/tests/__snapshots__/publish-dry-run.test.ts.snap
@@ -5,15 +5,15 @@ exports[`publish --dry-run success 1`] = `
   "exitCode": 0,
   "stderr": "",
   "stdout": "Dry-run dry-run-fixture@0.1.0
+Parsing CHANGELOG.md...
+Changelog:
+* Initial release
+
 Files:
   LICENSE
   README.md
   mops.toml
   src/lib.mo
-Parsing CHANGELOG.md...
-Changelog:
-* Initial release
-
-Dry-run OK — local preflight checks passed (4 files). Nothing was published.",
+Dry-run OK — local publish steps passed (4 files). Nothing was published.",
 }
 `;

--- a/cli/tests/publish-dry-run.test.ts
+++ b/cli/tests/publish-dry-run.test.ts
@@ -3,13 +3,21 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "path";
 import { cli, cliSnapshot, useTempFixtures } from "./helpers";
 
+const packagingArgs = [
+  "publish",
+  "--dry-run",
+  "--no-docs",
+  "--no-test",
+  "--no-bench",
+] as const;
+
 describe("publish --dry-run", () => {
   const fixturesDir = path.join(import.meta.dirname, "publish-dry-run");
   const makeTempFixture = useTempFixtures(fixturesDir);
 
   test("success", async () => {
     const cwd = path.join(fixturesDir, "success");
-    await cliSnapshot(["publish", "--dry-run"], { cwd, env: { CI: "1" } }, 0);
+    await cliSnapshot([...packagingArgs], { cwd, env: { CI: "1" } }, 0);
   });
 
   test("rejects local path dependencies", async () => {
@@ -26,7 +34,7 @@ license = "MIT"
 local-lib = "../local-lib"
 `,
     );
-    const result = await cli(["publish", "--dry-run"], {
+    const result = await cli([...packagingArgs], {
       cwd,
       env: { CI: "1" },
     });
@@ -37,7 +45,7 @@ local-lib = "../local-lib"
   test("rejects missing README.md", async () => {
     const cwd = await makeTempFixture("success");
     await rm(path.join(cwd, "README.md"));
-    const result = await cli(["publish", "--dry-run"], {
+    const result = await cli([...packagingArgs], {
       cwd,
       env: { CI: "1" },
     });
@@ -59,7 +67,7 @@ license = "MIT"
 files = ["**/*.mo", "extra/data.json"]
 `,
     );
-    const result = await cli(["publish", "--dry-run"], {
+    const result = await cli([...packagingArgs], {
       cwd,
       env: { CI: "1" },
     });
@@ -77,7 +85,7 @@ version = "0.1.0"
 license = "MIT"
 `,
     );
-    const result = await cli(["publish", "--dry-run"], {
+    const result = await cli([...packagingArgs], {
       cwd,
       env: { CI: "1" },
     });
@@ -101,11 +109,23 @@ license = "MIT"
 other = "https://github.com/org/repo#main:src"
 `,
     );
-    const result = await cli(["publish", "--dry-run"], {
+    const result = await cli([...packagingArgs], {
       cwd,
       env: { CI: "1" },
     });
     expect(result.exitCode).toBe(1);
     expect(result.stdout + result.stderr).toMatch(/GitHub dependencies/i);
+  });
+
+  test("runs the test step by default", async () => {
+    const cwd = path.join(fixturesDir, "success");
+    const result = await cli(
+      ["publish", "--dry-run", "--no-docs", "--no-bench"],
+      { cwd, env: { CI: "1" } },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/Running tests/);
+    expect(result.stdout).toMatch(/No test files found/);
+    expect(result.stdout).toMatch(/Dry-run OK/);
   });
 });

--- a/cli/tests/publish-dry-run.test.ts
+++ b/cli/tests/publish-dry-run.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "@jest/globals";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "path";
+import { cli, cliSnapshot, useTempFixtures } from "./helpers";
+
+describe("publish --dry-run", () => {
+  const fixturesDir = path.join(import.meta.dirname, "publish-dry-run");
+  const makeTempFixture = useTempFixtures(fixturesDir);
+
+  test("success", async () => {
+    const cwd = path.join(fixturesDir, "success");
+    await cliSnapshot(["publish", "--dry-run"], { cwd, env: { CI: "1" } }, 0);
+  });
+
+  test("rejects local path dependencies", async () => {
+    const cwd = await makeTempFixture("success");
+    await writeFile(
+      path.join(cwd, "mops.toml"),
+      `[package]
+name = "dry-run-fixture"
+version = "0.1.0"
+description = "Fixture for mops publish --dry-run"
+license = "MIT"
+
+[dependencies]
+local-lib = "../local-lib"
+`,
+    );
+    const result = await cli(["publish", "--dry-run"], {
+      cwd,
+      env: { CI: "1" },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toMatch(/local dependencies/i);
+  });
+
+  test("rejects missing README.md", async () => {
+    const cwd = await makeTempFixture("success");
+    await rm(path.join(cwd, "README.md"));
+    const result = await cli(["publish", "--dry-run"], {
+      cwd,
+      env: { CI: "1" },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toMatch(/README\.md/);
+  });
+
+  test("rejects unsupported file extension", async () => {
+    const cwd = await makeTempFixture("success");
+    await mkdir(path.join(cwd, "extra"), { recursive: true });
+    await writeFile(path.join(cwd, "extra", "data.json"), '{"ok":true}\n');
+    await writeFile(
+      path.join(cwd, "mops.toml"),
+      `[package]
+name = "dry-run-fixture"
+version = "0.1.0"
+description = "Fixture for mops publish --dry-run"
+license = "MIT"
+files = ["**/*.mo", "extra/data.json"]
+`,
+    );
+    const result = await cli(["publish", "--dry-run"], {
+      cwd,
+      env: { CI: "1" },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toMatch(/unsupported extension/i);
+  });
+});

--- a/cli/tests/publish-dry-run.test.ts
+++ b/cli/tests/publish-dry-run.test.ts
@@ -117,6 +117,48 @@ other = "https://github.com/org/repo#main:src"
     expect(result.stdout + result.stderr).toMatch(/GitHub dependencies/i);
   });
 
+  test("rejects oversized keywords", async () => {
+    const cwd = await makeTempFixture("success");
+    await writeFile(
+      path.join(cwd, "mops.toml"),
+      `[package]
+name = "dry-run-fixture"
+version = "0.1.0"
+description = "Fixture for mops publish --dry-run"
+license = "MIT"
+keywords = ["this-keyword-is-way-too-long"]
+`,
+    );
+    const result = await cli([...packagingArgs], {
+      cwd,
+      env: { CI: "1" },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toMatch(/max keyword length/i);
+  });
+
+  test("rejects package.files paths outside the package", async () => {
+    const cwd = await makeTempFixture("success");
+    await writeFile(
+      path.join(cwd, "mops.toml"),
+      `[package]
+name = "dry-run-fixture"
+version = "0.1.0"
+description = "Fixture for mops publish --dry-run"
+license = "MIT"
+files = ["../outside.mo"]
+`,
+    );
+    const result = await cli([...packagingArgs], {
+      cwd,
+      env: { CI: "1" },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toMatch(
+      /file path cannot start with/i,
+    );
+  });
+
   test("runs the test step by default", async () => {
     const cwd = path.join(fixturesDir, "success");
     const result = await cli(

--- a/cli/tests/publish-dry-run.test.ts
+++ b/cli/tests/publish-dry-run.test.ts
@@ -67,6 +67,26 @@ files = ["**/*.mo", "extra/data.json"]
     expect(result.stdout + result.stderr).toMatch(/unsupported extension/i);
   });
 
+  test("warns on missing description", async () => {
+    const cwd = await makeTempFixture("success");
+    await writeFile(
+      path.join(cwd, "mops.toml"),
+      `[package]
+name = "dry-run-fixture"
+version = "0.1.0"
+license = "MIT"
+`,
+    );
+    const result = await cli(["publish", "--dry-run"], {
+      cwd,
+      env: { CI: "1" },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(
+      /Missing recommended config key "description"/,
+    );
+  });
+
   test("rejects GitHub dependencies", async () => {
     const cwd = await makeTempFixture("success");
     await writeFile(

--- a/cli/tests/publish-dry-run.test.ts
+++ b/cli/tests/publish-dry-run.test.ts
@@ -66,4 +66,26 @@ files = ["**/*.mo", "extra/data.json"]
     expect(result.exitCode).toBe(1);
     expect(result.stdout + result.stderr).toMatch(/unsupported extension/i);
   });
+
+  test("rejects GitHub dependencies", async () => {
+    const cwd = await makeTempFixture("success");
+    await writeFile(
+      path.join(cwd, "mops.toml"),
+      `[package]
+name = "dry-run-fixture"
+version = "0.1.0"
+description = "Fixture for mops publish --dry-run"
+license = "MIT"
+
+[dependencies]
+other = "https://github.com/org/repo#main:src"
+`,
+    );
+    const result = await cli(["publish", "--dry-run"], {
+      cwd,
+      env: { CI: "1" },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toMatch(/GitHub dependencies/i);
+  });
 });

--- a/cli/tests/publish-dry-run/success/CHANGELOG.md
+++ b/cli/tests/publish-dry-run/success/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release

--- a/cli/tests/publish-dry-run/success/LICENSE
+++ b/cli/tests/publish-dry-run/success/LICENSE
@@ -1,0 +1,3 @@
+MIT License
+
+Copyright (c) 2026

--- a/cli/tests/publish-dry-run/success/README.md
+++ b/cli/tests/publish-dry-run/success/README.md
@@ -1,0 +1,3 @@
+# dry-run-fixture
+
+Test fixture for `mops publish --dry-run`.

--- a/cli/tests/publish-dry-run/success/mops.toml
+++ b/cli/tests/publish-dry-run/success/mops.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dry-run-fixture"
+version = "0.1.0"
+description = "Fixture for mops publish --dry-run"
+license = "MIT"
+
+[dependencies]
+core = "1.0.0"

--- a/cli/tests/publish-dry-run/success/src/lib.mo
+++ b/cli/tests/publish-dry-run/success/src/lib.mo
@@ -1,0 +1,5 @@
+module {
+  public func hello() : Text {
+    "hello";
+  };
+};

--- a/docs/docs/cli/2-publish/01-mops-publish.md
+++ b/docs/docs/cli/2-publish/01-mops-publish.md
@@ -30,7 +30,21 @@ You can also view the diff of the benchmark results between the current version 
 
 Packages may contain up to **1000 files**. If your package exceeds this limit, `mops publish` will exit early with an error before contacting the registry.
 
+## Dry run
+
+Validate local packaging rules and list the files that would be uploaded, without contacting the registry or uploading anything:
+
+```
+mops publish --dry-run
+```
+
+Checks `[package]` metadata, dependency shape (no local or GitHub deps), required files (`mops.toml`, `README.md`), allowed extensions, and the file-count limit. Always prints the resolved file list.
+
+Does **not** run tests, generate docs, run benchmarks, or verify registry acceptance (already published, permissions, missing deps, etc.). A real `mops publish` can still fail after a successful dry run. Generated `docs.tgz` is also not included in the dry-run file list (it is added only during a real publish when docs are enabled).
+
 ## Options
+
+`--dry-run` - Validate local packaging rules and list files without publishing
 
 `--no-docs` - Do not generate docs
 
@@ -39,4 +53,3 @@ Packages may contain up to **1000 files**. If your package exceeds this limit, `
 `--no-bench` - Do not run benchmarks
 
 `--verbose` - Verbose output (print file names to be uploaded)
-

--- a/docs/docs/cli/2-publish/01-mops-publish.md
+++ b/docs/docs/cli/2-publish/01-mops-publish.md
@@ -32,15 +32,17 @@ Packages may contain up to **1000 files**. If your package exceeds this limit, `
 
 ## Dry run
 
-Validate local packaging rules and list the files that would be uploaded, without contacting the registry or uploading anything:
+Run the same local preflight checks as `mops publish` before upload, and on success print the files that would be uploaded — without contacting the network or uploading anything:
 
 ```
 mops publish --dry-run
 ```
 
-Checks `[package]` metadata, dependency shape (no local or GitHub deps), required files (`mops.toml`, `README.md`), allowed extensions, and the file-count limit. Always prints the resolved file list.
+Does **not** require an imported identity and does **not** contact the network.
 
-Does **not** run tests, generate docs, run benchmarks, or verify registry acceptance (already published, permissions, missing deps, etc.). A real `mops publish` can still fail after a successful dry run. Generated `docs.tgz` is also not included in the dry-run file list (it is added only during a real publish when docs are enabled).
+Covers field length limits, dependency shape (no local or GitHub deps), required files (`mops.toml`, `README.md`), allowed extensions, and the file-count limit.
+
+Does **not** run tests, generate docs, run benchmarks, or run canister config validation (SPDX license, semver, name charset/reserved names, keyword format). Also does not prove registry acceptance (already published, permissions, missing deps). A real `mops publish` can still fail after a successful dry run. Generated `docs.tgz` is also not included in the dry-run file list (it is added only during a real publish when docs are enabled).
 
 ## Options
 
@@ -52,4 +54,4 @@ Does **not** run tests, generate docs, run benchmarks, or verify registry accept
 
 `--no-bench` - Do not run benchmarks
 
-`--verbose` - Verbose output (print file names to be uploaded)
+`--verbose` - Verbose output (print file names to be uploaded; on `--dry-run` the file list is always printed)

--- a/docs/docs/cli/2-publish/01-mops-publish.md
+++ b/docs/docs/cli/2-publish/01-mops-publish.md
@@ -32,21 +32,21 @@ Packages may contain up to **1000 files**. If your package exceeds this limit, `
 
 ## Dry run
 
-Run the same local preflight checks as `mops publish` before upload, and on success print the files that would be uploaded — without contacting the network or uploading anything:
+Run the same local publish steps as `mops publish` (packaging checks, docs, tests, benchmarks, changelog) and on success print the final file list — without contacting the registry or uploading anything:
 
 ```
 mops publish --dry-run
 ```
 
-Does **not** require an imported identity and does **not** contact the network.
+Does **not** require an imported identity and does **not** contact the mops registry. `--no-docs`, `--no-test`, and `--no-bench` work the same as for a real publish.
 
-Covers field length limits, dependency shape (no local or GitHub deps), required files (`mops.toml`, `README.md`), allowed extensions, and the file-count limit.
+Does **not** run canister config validation (SPDX license, semver, name charset/reserved names, keyword format) or prove registry acceptance (already published, permissions, missing deps). A real `mops publish` can still fail after a successful dry run.
 
-Does **not** run tests, generate docs, run benchmarks, or run canister config validation (SPDX license, semver, name charset/reserved names, keyword format). Also does not prove registry acceptance (already published, permissions, missing deps). A real `mops publish` can still fail after a successful dry run. Generated `docs.tgz` is also not included in the dry-run file list (it is added only during a real publish when docs are enabled).
+When docs are enabled, the file list includes the generated `docs.tgz` (cleaned up after the dry run).
 
 ## Options
 
-`--dry-run` - Validate local packaging rules and list files without publishing
+`--dry-run` - Run local publish steps without contacting the registry or uploading
 
 `--no-docs` - Do not generate docs
 
@@ -54,4 +54,4 @@ Does **not** run tests, generate docs, run benchmarks, or run canister config va
 
 `--no-bench` - Do not run benchmarks
 
-`--verbose` - Verbose output (print file names to be uploaded; on `--dry-run` the file list is always printed)
+`--verbose` - Verbose output (print file names to be uploaded; on `--dry-run` the final file list is always printed)

--- a/docs/docs/cli/2-publish/01-mops-publish.md
+++ b/docs/docs/cli/2-publish/01-mops-publish.md
@@ -32,13 +32,15 @@ Packages may contain up to **1000 files**. If your package exceeds this limit, `
 
 ## Dry run
 
-Run the same local publish steps as `mops publish` (packaging checks, docs, tests, benchmarks, changelog) and on success print the final file list — without contacting the registry or uploading anything:
+Run the same local publish steps as `mops publish` (packaging checks, docs, changelog, tests, benchmarks) and on success print the final file list — without contacting the registry or uploading anything:
 
 ```
 mops publish --dry-run
 ```
 
 Does **not** require an imported identity and does **not** contact the mops registry. `--no-docs`, `--no-test`, and `--no-bench` work the same as for a real publish.
+
+May still fetch GitHub release notes when `CHANGELOG.md` has no entry for the version and `[package].repository` is a GitHub URL (same as a real publish).
 
 Does **not** run canister config validation (SPDX license, semver, name charset/reserved names, keyword format) or prove registry acceptance (already published, permissions, missing deps). A real `mops publish` can still fail after a successful dry run.
 


### PR DESCRIPTION
`mops publish --dry-run` runs the same local publish steps as a real publish (packaging checks, docs, changelog, tests, benchmarks), prints the final file list, and stops before identity / registry upload.

Catches local failures that would otherwise only show up on a real publish. `--no-docs` / `--no-test` / `--no-bench` work the same as for `mops publish`.

### Before
```
$ mops publish --dry-run
error: unknown option '--dry-run'
```

### After
```
$ mops publish --dry-run
Dry-run my-pkg@0.1.0
Generating documentation...
Parsing CHANGELOG.md...
Running tests...
Running benchmarks...
Files:
  .mops/.docs/docs.tgz
  LICENSE
  README.md
  mops.toml
  src/lib.mo
Dry-run OK — local publish steps passed (5 files). Nothing was published.
```

## What is unchanged
Does **not** contact the mops registry, require an imported identity, run canister config validation (SPDX/semver/name rules), or prove registry acceptance (already published, permissions, missing deps). May still fetch GitHub release notes when changelog is missing (same as a real publish). A real `mops publish` can still fail after a successful dry run.