### PR TITLE
fix(cli-releases): sync frontend package-lock with package.json

### DIFF
--- a/cli-releases/frontend/package-lock.json
+++ b/cli-releases/frontend/package-lock.json
@@ -3210,6 +3210,21 @@
         }
       }
     },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/svelte-eslint-parser": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.43.0.tgz",


### PR DESCRIPTION
`npm ci` in `cli-releases/frontend` was broken on `main`: `picomatch@4.0.5` — an optional peer dependency of `svelte-check` — was resolved in `node_modules` but never written to the lock file.

Before:

```
$ cd cli-releases/frontend && npm ci
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: picomatch@4.0.5 from lock file
```

After:

```
$ cd cli-releases/frontend && npm ci
added 222 packages, and audited 223 packages in 1s
```

Regenerated with `npm install --package-lock-only`, which adds exactly one `node_modules/svelte-check/node_modules/picomatch` entry (dev/optional/peer). No other resolution moved. `npm run build-cli-releases` still succeeds.

## Why CI didn't catch it

`cli-releases` *is* exercised — `ci.yml` runs `npm run build-cli-releases`, and `release.yml` runs `npm ci` in `cli-releases` — but no workflow ever runs `npm ci` in `cli-releases/frontend`. The nested install goes through `cli-releases/package.json`'s `postinstall: cd frontend && npm install`, and `npm install` silently repairs lock-file drift instead of failing on it. Every other sub-project (`frontend`, `cli`, `docs`, `blog`) gets a direct `npm ci` from the root `ci:postinstall`; `cli-releases/frontend` is the one that only ever sees `npm install`.

Worth noting: because `release.yml` does `git add cli-releases/` after that install, the next CLI release would have swept this same one-line fix into its artifacts PR unnoticed.

## Out of scope

Closing the CI gap itself — switching that `postinstall` to `npm ci`, or adding a lock-file-drift check — is a separate change; flipping it to `npm ci` would break the local `npm install` bootstrap path that the root `postinstall` relies on. Left for a follow-up.

Found incidentally during unrelated security dependency work; no advisory involved.
