### PR TITLE
test(bench): stop asserting one moc version's error wording

### DIFF
--- a/cli/tests/bench.test.ts
+++ b/cli/tests/bench.test.ts
@@ -3,8 +3,11 @@ import { rmSync } from "node:fs";
 import path from "path";
 import { cli } from "./helpers";
 
-// Pin moc 1.3.0 (≥ 0.15) to exercise the EOP path — this repo's own mops.toml
-// uses moc 0.14.14, so the default bench run is never EOP-tested here.
+// The fixtures pin moc 1.3.0 (≥ 0.15) to exercise the EOP path — this repo's own
+// mops.toml uses moc 0.14.14, so the default bench run is never EOP-tested here.
+// The pin only applies when the toolchain wrapper is active (DFX_MOC_PATH=moc-wrapper,
+// which CI auto-inits); a plain dev shell gets the dfx-bundled moc instead, so
+// assertions here must not depend on one moc version's wording.
 describe("bench", () => {
   jest.setTimeout(180_000);
 
@@ -25,7 +28,11 @@ describe("bench", () => {
     try {
       const result = await cli(["bench"], { cwd });
       expect(result.exitCode).not.toBe(0);
-      expect(result.stderr).toMatch(/invalid warning code/);
+      // Wording depends on the moc that runs (1.3.0: `invalid warning code: …`,
+      // dfx-bundled 0.16.1: `unknown option '…'` plus a --help dump), but both
+      // echo the whole entry back in one diagnostic — that is the invariant: it
+      // reached moc as a single argument instead of being split on the space.
+      expect(result.stderr).toMatch(/moc: [^\n]*M0154 --legacy-persistence/);
     } finally {
       rmSync(path.join(cwd, ".mops"), { recursive: true, force: true });
     }


### PR DESCRIPTION
`mops bench` resolves `moc` through `getMocPath()` — `DFX_MOC_PATH`, else dfx's bundled compiler — and never consults `[toolchain] moc` (unlike `mops test`/`check`/`build`, which go through `toolchain.bin("moc")`). So the `moc = "1.3.0"` pin in `cli/tests/bench/moc-args-invalid/mops.toml` only takes effect when the toolchain wrapper is active. CI gets that for free: `mops toolchain use moc 0.14.13` auto-inits the wrapper under `CI` and exports `DFX_MOC_PATH=moc-wrapper` through `$GITHUB_ENV`, so every CI job actually ran the pinned moc 1.3.0 — which reports `moc: invalid warning code: M0154 --legacy-persistence`, the string the test matched verbatim.

Without that export, `mops bench` runs dfx 0.29.1's moc 0.16.1 instead. That version predates `-E=<code>` and answers `moc: unknown option '-E=M0154 --legacy-persistence'.` followed by its entire `--help` dump — the same intended failure, different wording. Hence the one red test on `main` on a dev machine, invisible to CI. (Measured: 0.14.14 and 0.16.1 say `unknown option`; 0.16.3, 1.2.0 and 1.3.0 say `invalid warning code`.)

The assertion now matches `/moc: [^\n]*M0154 --legacy-persistence/` — a moc diagnostic that echoes the entry back with its embedded space intact. That is the invariant the test exists for: the entry reached moc as a single argument rather than being split on the space, and it holds under either wording. It also can't pass for the wrong reason. Feeding `mops bench` the split form (`args = ["-E=M0154", "--legacy-persistence"]`, i.e. what the pre-#615 bug produced) fails the test in both environments: moc 0.16.1 names only `-E=M0154`, and moc 1.3.0 accepts both flags and exits 0. The `moc: ` prefix is what keeps the pattern off execa's command echo, which quotes the same string whenever the compiler fails for any reason.

Test-only, so no `cli/CHANGELOG.md` entry — nothing user-facing changed.

Closes #656
