### PR TITLE
ci: add Prepare CLI release workflow

### DIFF
--- a/.github/workflows/prepare-cli-release.yml
+++ b/.github/workflows/prepare-cli-release.yml
@@ -1,0 +1,163 @@
+name: Prepare CLI release
+
+# Creates a release PR (changelog rollup + version bump). On merge,
+# release-pr.yml tags cli-vX.Y.Z and release.yml publishes.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Semver bump
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+concurrency:
+  group: prepare-cli-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions: {} # privileged ops use the GitHub App token, not GITHUB_TOKEN
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        id: app-token
+        with:
+          app-id: ${{ vars.GENERIC_CI_RW_APP_ID }}
+          private-key: ${{ secrets.GENERIC_CI_RW_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+
+      - name: Abort if open release PR exists
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          OPEN=$(gh pr list --label release --state open --json number,url --jq 'length')
+          if [[ "$OPEN" != "0" ]]; then
+            echo "::error::An open release PR already exists:"
+            gh pr list --label release --state open
+            exit 1
+          fi
+
+      - name: Abort if ## Next has no entries
+        working-directory: cli
+        run: |
+          set -euo pipefail
+          NOTES=$(awk '/^## Next$/{found=1; next} found && /^## /{exit} found' CHANGELOG.md)
+          if ! echo "$NOTES" | grep -qE '^- '; then
+            echo "::error::## Next in cli/CHANGELOG.md has no changelog entries to release"
+            exit 1
+          fi
+
+      - name: Bump version
+        id: bump
+        working-directory: cli
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          VERSION=$(npm version "$BUMP" --no-git-tag-version | sed 's/^v//')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumped to $VERSION ($BUMP)"
+
+      - name: Abort if version already released
+        working-directory: cli
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+          ESCAPED=$(echo "$VERSION" | sed 's/\./\\./g')
+          if grep -qE "^## ${ESCAPED}$" CHANGELOG.md; then
+            echo "::error::Changelog already has a ## ${VERSION} heading"
+            exit 1
+          fi
+          if git rev-parse "refs/tags/cli-v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag cli-v${VERSION} already exists"
+            exit 1
+          fi
+
+      - name: Roll ## Next into version heading
+        working-directory: cli
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+          NOTES_FILE=$(mktemp)
+          awk '/^## Next$/{found=1; next} found && /^## /{exit} found' CHANGELOG.md > "$NOTES_FILE"
+
+          awk -v version="$VERSION" -v notesfile="$NOTES_FILE" '
+            /^## Next$/ {
+              print "## Next"
+              print ""
+              print "## " version
+              started = 0
+              while ((getline line < notesfile) > 0) {
+                if (!started) {
+                  if (line ~ /^[[:space:]]*$/) continue
+                  started = 1
+                }
+                print line
+              }
+              close(notesfile)
+              print ""
+              while ((getline) > 0) {
+                if ($0 ~ /^## /) {
+                  print
+                  break
+                }
+              }
+              next
+            }
+            { print }
+          ' CHANGELOG.md > /tmp/CHANGELOG.md
+          mv /tmp/CHANGELOG.md CHANGELOG.md
+          rm -f "$NOTES_FILE"
+
+          # Sanity: version section must be non-empty (same check as release-pr.yml)
+          ESCAPED=$(echo "$VERSION" | sed 's/\./\\./g')
+          NOTES=$(awk "/^## ${ESCAPED}$/{found=1; next} found && /^## /{exit} found" CHANGELOG.md)
+          if [[ -z "$NOTES" ]]; then
+            echo "::error::Changelog rewrite left an empty ## ${VERSION} section"
+            exit 1
+          fi
+          echo "Changelog updated for v${VERSION}."
+
+      - name: Create release PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="ci/release-${VERSION}"
+          git checkout -b "$BRANCH"
+          git add cli/CHANGELOG.md cli/package.json cli/package-lock.json
+          git commit -m "release: CLI v${VERSION}"
+          git push -u origin "$BRANCH"
+
+          printf -v BODY 'Release CLI v%s.\n\nPrepared by the [Prepare CLI release](https://github.com/%s/actions/workflows/prepare-cli-release.yml) workflow.\n\nApprove this PR when CI is green — auto-merge is enabled.' \
+            "$VERSION" "${{ github.repository }}"
+
+          gh pr create \
+            --title "release: CLI v${VERSION}" \
+            --body "$BODY" \
+            --label release \
+            --base main
+
+          gh pr merge --auto --squash

--- a/cli/RELEASE.md
+++ b/cli/RELEASE.md
@@ -1,6 +1,28 @@
 # Mops CLI Release
 
-## 1. Update changelog
+## Automated (preferred)
+
+1. Ensure `## Next` in [`CHANGELOG.md`](CHANGELOG.md) has the entries you want to ship.
+2. Run [**Prepare CLI release**](https://github.com/caffeinelabs/mops/actions/workflows/prepare-cli-release.yml) → choose `patch` / `minor` / `major`.
+3. Approve the release PR when CI is green (auto-merge is already enabled).
+
+That workflow rolls `## Next` into a version heading, bumps `cli/package.json`, and opens a PR titled `release: CLI vX.Y.Z` with the `release` label.
+
+The [`release-pr.yml`](../.github/workflows/release-pr.yml) workflow validates the PR (title, changelog entry, `package.json` version). On merge it pushes the `cli-vX.Y.Z` tag, which triggers [`release.yml`](../.github/workflows/release.yml) — build, npm publish, GitHub Release, and deploy of `cli.mops.one` / `docs.mops.one`.
+
+> **Note:** This pipeline only deploys the `cli` and `docs` canisters. The `main`, `assets`, `blog`, and `play-frontend` canisters require a manual deploy. If a release includes changes to any of those (e.g. `backend/main/` or `frontend/`), upgrade them manually (staging first, then `ic`):
+>
+> ```bash
+> NODE_ENV=production dfx deploy --no-wallet --identity mops --network <staging|ic> <canister>
+> ```
+
+## Artifacts PR
+
+After the release pipeline completes, it creates and auto-merges a `cli-releases: vX.Y.Z artifacts` PR. No action needed unless it fails — monitor at [Actions → Release CLI](https://github.com/caffeinelabs/mops/actions/workflows/release.yml) and merge the artifacts PR manually if needed.
+
+## Manual fallback
+
+### 1. Update changelog
 
 Move items from `## Next` in `CHANGELOG.md` into a new version heading:
 
@@ -14,14 +36,14 @@ Move items from `## Next` in `CHANGELOG.md` into a new version heading:
 
 The heading must match the exact version string — the release workflow parses it to extract release notes.
 
-## 2. Bump version
+### 2. Bump version
 
 ```bash
 cd cli
 npm version patch --no-git-tag-version  # or: minor / major
 ```
 
-## 3. Create a release PR and enable auto-merge
+### 3. Create a release PR and enable auto-merge
 
 ```bash
 git checkout -b <username>/release-X.Y.Z
@@ -34,23 +56,6 @@ gh pr create \
   --label release
 gh pr merge --auto --squash
 ```
-
-The [`release-pr.yml`](../.github/workflows/release-pr.yml) workflow runs on every update and validates:
-- PR title matches `release: CLI vX.Y.Z`
-- `cli/CHANGELOG.md` has an entry for the version
-- `cli/package.json` version matches
-
-Once all required checks pass the PR merges automatically. On merge, `release-pr.yml` pushes the `cli-vX.Y.Z` tag, which triggers the [`release.yml`](../.github/workflows/release.yml) workflow — it builds, publishes to npm, creates a GitHub Release, and deploys canisters (`cli.mops.one` and `docs.mops.one`).
-
-> **Note:** This workflow only deploys the `cli` and `docs` canisters. The `main`, `assets`, `blog`, and `play-frontend` canisters require a manual deploy. If a release includes changes to any of those (e.g. `backend/main/` or `frontend/`), upgrade them manually (staging first, then `ic`):
->
-> ```bash
-> NODE_ENV=production dfx deploy --no-wallet --identity mops --network <staging|ic> <canister>
-> ```
-
-## 5. Artifacts PR
-
-After the release pipeline completes, it creates and auto-merges a `cli-releases: vX.Y.Z artifacts` PR. No action needed unless it fails — monitor at [Actions → Release CLI](https://github.com/caffeinelabs/mops/actions/workflows/release.yml) and merge the artifacts PR manually if needed.
 
 ## Verify build
 


### PR DESCRIPTION
CLI releases can be prepared from Actions instead of hand-editing the changelog, bumping the version, and opening the release PR locally.

**Before:** update `## Next`, `npm version`, push a branch, `gh pr create --label release`, enable auto-merge.

**After:** [Prepare CLI release](https://github.com/caffeinelabs/mops/actions/workflows/prepare-cli-release.yml) → choose `patch` / `minor` / `major` → Approve the PR when CI is green (auto-merge is already on).

Existing `release-pr.yml` → tag → `release.yml` publish path is unchanged. Manual steps remain documented as a fallback in `cli/RELEASE.md`.


Made with [Cursor](https://cursor.com)