### PR TITLE
chore(cli)!: require Node >= 20, drop mocv detection and legacy re-exports

### DIFF
--- a/NEXT-MAJOR.md
+++ b/NEXT-MAJOR.md
@@ -60,7 +60,7 @@ Compromise (2026-07): we have not migrated our own dev loop to `icp` yet, so v3 
 
 ### Toolchain & runtime
 
-- Drop Node.js < 20 (`cli/package.json` engines currently `>=18.0.0`). (GH #288)
+- ~~Drop Node.js < 20 (`cli/package.json` engines currently `>=18.0.0`)~~ — **done on `v3`** (engines now `>=20.0.0`). (GH #288)
 - **Drop the legacy PocketIC client** (decision 2026-07; **deprecated in 2.x, drop here** — decision 2026-08-03 to split rather than hold the whole switch for v3, matching the dfx-replica/vessel deprecate-then-drop pattern): delete the `pic-ic` 0.5.4 dep and the `< 9.0.0` switch in `cli/helpers/pocket-ic-client.ts`; upstream `@dfinity/pic` (switched to in 2.x, see below) becomes the only client, killing the `AnyPocketIcServer`/`AnyPocketIc`/`AnySetupCanister` union types that leak into `test`/`bench`/`replica`/`bench-replica`/`watch` signatures. Breaks only explicit `[toolchain] pocket-ic < 9.0.0` pins — error with the verbatim fix (`mops toolchain use pocket-ic 12.0.0`). Unpinned projects never hit it (they get `DEFAULT_POCKET_IC_VERSION`). Subsumes the old "PocketIC v9 → v10" item (GH #288): with one client, enforce a **supported server range** (floor 9.0.0, ceiling = shipped client's max) at `toolchain use` time — fixes the `latest`-resolves-to-incompatible-server footgun (see AGENTS.md caution); future ceiling raises are routine client updates, not majors. Keep the range as a maintained constant pair next to `DEFAULT_POCKET_IC_VERSION`.
 - ~~**Eliminate the `pic-js-mops` fork**~~ — **done, shipped in 2.x** (caffeinelabs/mops#642, merged 2026-08-03; closed GH #561). The fork had no public source repo; the two patches mops needed went upstream as dfinity/pic-js#276 (`binPath` + `POCKET_IC_BIN`) and #278 (`ttl`), released in `@dfinity/pic` 0.23.0. `pocket-ic` >= 9.0.0 now runs on upstream pic; `pic-ic` remains only for the deprecated `< 9.0.0` pins removed by the item above. `pic-js-mops` cannot be deprecated on npm — nobody has publish access (GH #657, closed).
 
@@ -86,8 +86,8 @@ Carried over from that work, all tracked as issues:
 
 - `mops install` semantics change (drop CI env auto-detection, drop implicit `.mops/` re-hash).
 - Bump `apiVersion` (CLI ↔ backend) only if schema-affecting changes land — nothing in this scope requires it.
-- Remove `// compatibility with older versions` re-exports (`cli/mops.ts:324-325`).
-- Drop legacy mocv detection in `cli/commands/docs.ts:44-49` and `cli/commands/toolchain/index.ts:80-95,132-138`.
+- ~~Remove `// compatibility with older versions` re-exports (`cli/mops.ts:324-325`)~~ — **done on `v3`** (the one in-repo user, `cli/cache.ts`, now imports `getNetwork` from `cli/api/network.ts`).
+- ~~Drop legacy mocv detection in `cli/commands/docs.ts:44-49` and `cli/commands/toolchain/index.ts:80-95,132-138`~~ — **done on `v3`**.
 
 ### Decide before release
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+## 3.0.0 (unreleased)
+- **Breaking**: Node.js >= 20 is required (`engines` bump from >= 18); installs on Node 18 fail with an engines error. (#288)
+- Removed legacy `mocv` detection: `mops toolchain init` no longer refuses to run when `mocv` is installed (and no longer strips mocv-era `DFX_MOC_PATH` lines from shell configs), and `mops docs` no longer resolves `mo-doc` from a mocv-managed `DFX_MOC_PATH`. Use `mops toolchain use moc <version>` to pin the compiler.
+
 ## 2.20.0
 - Fix `mops bench` (and `mops sync`, `mops watch`) ignoring `[toolchain] moc` and always resolving the compiler via `DFX_MOC_PATH` / `dfx cache show`, unlike `mops build`/`test`/`check`/`check-stable`/`generate`/`docs`. A pinned `[toolchain] moc` is now the compiler these commands invoke, regardless of `DFX_MOC_PATH`.
 - `.tar.xz` toolchain archives (`lintoko`, `wasmtime`) are now unpacked with `tar` plus a standalone xz decompressor instead of `decompress` and its `decomp-tarxz` plugin. Extraction output is unchanged — same files, same permissions — but `decompress` is unmaintained, with two open critical advisories and no fixed version, so the toolchain download path no longer depends on it. Failures during unpacking now surface as errors instead of being swallowed and reported later as a missing-directory copy error, and the temporary download directory is always cleaned up. `decomp-tarxz` is no longer a runtime dependency of the published CLI.

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,7 +10,7 @@ Mops is a package manager for the Motoko programming language.
 ## Setup
 
 ### 1. Check system requirements
-- [Node.js](https://nodejs.org/)
+- [Node.js](https://nodejs.org/) >= 20.0.0
 - [DFX](https://internetcomputer.org/docs/current/developer-docs/quickstart/local-quickstart) >= 0.10.0
 
 ### 2. Install CLI tool

--- a/cli/cache.ts
+++ b/cli/cache.ts
@@ -5,11 +5,11 @@ import getFolderSize from "get-folder-size";
 
 import {
   getDependencyType,
-  getNetwork,
   getRootDir,
   globalCacheDir,
   parseGithubURL,
 } from "./mops.js";
+import { getNetwork } from "./api/network.js";
 import { getPackageId } from "./helpers/get-package-id.js";
 
 let getGlobalCacheDir = () => {

--- a/cli/commands/docs.ts
+++ b/cli/commands/docs.ts
@@ -11,8 +11,6 @@ import streamToPromise from "stream-to-promise";
 import { getRootDir } from "../mops.js";
 import { toolchain } from "./toolchain/index.js";
 
-let moDocPath: string;
-
 type DocsOptions = {
   source: string;
   output: string;
@@ -41,17 +39,9 @@ export async function docs(options: Partial<DocsOptions> = {}) {
 
   deleteSync([docsDir], { force: true });
 
-  // detect mocv (legacy)
-  if (
-    process.env.DFX_MOC_PATH &&
-    process.env.DFX_MOC_PATH.includes("mocv/versions")
-  ) {
-    moDocPath = process.env.DFX_MOC_PATH.replace(/\/moc$/, "/mo-doc");
-  } else {
-    // fallbacks to dfx moc if not specified in config
-    let mocPath = await toolchain.bin("moc", { fallback: true });
-    moDocPath = mocPath.replace(/\/moc$/, "/mo-doc");
-  }
+  // fallbacks to dfx moc if not specified in config
+  let mocPath = await toolchain.bin("moc", { fallback: true });
+  let moDocPath = mocPath.replace(/\/moc$/, "/mo-doc");
 
   // generate docs
   await new Promise<void>((resolve) => {

--- a/cli/commands/toolchain/index.ts
+++ b/cli/commands/toolchain/index.ts
@@ -96,25 +96,6 @@ async function init({ reset = false, silent = false } = {}) {
     process.exit(1);
   }
 
-  try {
-    let res = execSync("which mocv").toString().trim();
-    if (res) {
-      console.error(
-        "Mops is not compatible with mocv. Please uninstall mocv and try again.",
-      );
-      console.log("Steps to uninstall mocv:");
-      console.log('1. Run "mocv reset"');
-      console.log('2. Run "npm uninstall -g mocv"');
-      console.log(
-        'TIP: Alternative to "mocv use <version>" is "mops toolchain use moc <version>" (installs moc only for current project)',
-      );
-      console.log("TIP: More details at https://docs.mops.one/cli/toolchain");
-      if (!process.env.CI || !silent) {
-        process.exit(1);
-      }
-    }
-  } catch {}
-
   let zshrc = path.join(os.homedir(), ".zshrc");
   let bashrc = path.join(os.homedir(), ".bashrc");
   let bashProfile = path.join(os.homedir(), ".bash_profile");
@@ -149,13 +130,7 @@ async function init({ reset = false, silent = false } = {}) {
 
     let newLines = [setDfxMocPathLine];
 
-    let oldLines = [
-      // legacy mocv lines
-      `\nexport DFX_MOC_PATH=${path.join(path.join(os.homedir(), ".cache/mocv"), "versions/current")}/moc`,
-      '\nexport DFX_MOC_PATH="$HOME/.cache/mocv/versions/current/moc"',
-      // new
-      setDfxMocPathLine,
-    ];
+    let oldLines = [setDfxMocPathLine];
 
     // remove old lines
     for (let oldLine of oldLines) {

--- a/cli/mops.ts
+++ b/cli/mops.ts
@@ -8,9 +8,7 @@ import prompts from "prompts";
 import { decodeFile } from "./pem.js";
 import { cliError } from "./error.js";
 import { Config, Dependency } from "./types.js";
-import { mainActor, storageActor } from "./api/actors.js";
-import { getNetwork } from "./api/network.js";
-import { getHighestVersion } from "./api/getHighestVersion.js";
+import { mainActor } from "./api/actors.js";
 import { getPackageId } from "./helpers/get-package-id.js";
 import { FILE_PATH_REGEX } from "./constants.js";
 
@@ -320,6 +318,3 @@ export function version() {
   );
   return packageJson.version;
 }
-
-// compatibility with older versions
-export { getNetwork, mainActor, storageActor, getHighestVersion };

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -80,7 +80,7 @@
         "wasm-pack": "0.15.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -21,7 +21,7 @@
   "author": "DFINITY",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "mops": "tsx ./environments/nodejs/cli",


### PR DESCRIPTION
Part of v3 (NEXT-MAJOR.md "Toolchain & runtime" / "Cleanup that affects users"). Targets the `v3` integration branch.

Node.js 18 is no longer supported: `cli/package.json` engines is now `>=20.0.0`, so `npm i -g ic-mops@3` on Node 18 fails with an engines error (part of [#288](https://github.com/caffeinelabs/mops/issues/288)). CI already tests 22/24/26 and the docs quick-start already states `>= 20.0.0`; the CLI README now says so too. No Node-18 compat workarounds existed in the code (`--experimental-vm-modules` in the Jest script is an ESM requirement, still needed on 20+).

The rest was dead weight from the pre-toolchain era:

- **mocv detection dropped.** `mops toolchain init` no longer refuses to run when `mocv` is on PATH (and no longer strips mocv-era `DFX_MOC_PATH` lines from shell configs), and `mops docs` no longer resolves `mo-doc` from a mocv-managed `DFX_MOC_PATH` — it always goes through the toolchain (pinned `[toolchain] moc`, dfx fallback). Verified in a temp project with `moc = "0.16.1"` pinned: `mops toolchain bin moc` and `mops docs generate` both work.
- **`// compatibility with older versions` re-exports removed** from `cli/mops.ts` (`getNetwork`, `mainActor`, `storageActor`, `getHighestVersion`). One in-repo user was still on the legacy path: `cli/cache.ts` imported `getNetwork` from `./mops.js`; it now imports from `./api/network.js`. Nothing else in the repo (including test fixtures and `.agents/`) used them.

`npm run check` clean, full CLI Jest green (24 suites, 193 tests).

## What is unchanged

`cli/package.json` is otherwise untouched — dep bumps and `files` changes belong to sibling v3 PRs. `blog/` and `docs/` keep their own Docusaurus `engines`; those are site build requirements, not the CLI's.
