### PR TITLE
docs: link between pages with relative paths, not site-absolute

### DIFF
--- a/docs/docs/00-introduction.md
+++ b/docs/docs/00-introduction.md
@@ -9,7 +9,7 @@ Mops aims to be a one-stop solution for all your Motoko development needs.
 
 Mops empowers and simplifies Motoko developer experience.
 
-Learn how to start using Mops in [Quick Start](/quick-start).
+Learn how to start using Mops in [Quick Start](./01-quick-start.md).
 
 ## What is Mops?
 
@@ -27,16 +27,16 @@ You can discover Motoko packages on [mops.one](https://mops.one/).
 
 ### Mops is a test runner for Motoko
 
-Mops comes with a [test runner](/cli/mops-test) that follows [Mops Message Format](https://github.com/caffeinelabs/mops-message-format) and works with the [`test` package](https://mops.one/test).
+Mops comes with a [test runner](./cli/4-dev/01-mops-test.md) that follows [Mops Message Format](https://github.com/caffeinelabs/mops-message-format) and works with the [`test` package](https://mops.one/test).
 
 ### Mops is a benchmarking tool for Motoko
 
-Mops comes with a [benchmarking tool](/cli/mops-bench) that works with the [`bench` package](https://mops.one/bench).
+Mops comes with a [benchmarking tool](./cli/4-dev/02-mops-bench.md) that works with the [`bench` package](https://mops.one/bench).
 
 ### Mops is a toolchain manager for Motoko
 
-[`mops toolchain`](/cli/toolchain) helps you install and manage Motoko toolchain, including `moc`, `pocket-ic`, `wasmtime`, and `lintoko`.
+[`mops toolchain`](./cli/5-toolchain/01-toolchain-overview.md) helps you install and manage Motoko toolchain, including `moc`, `pocket-ic`, `wasmtime`, and `lintoko`.
 
 ### Mops is an essential tool for Motoko developers
 
-Use [`mops watch`](/cli/mops-watch) to check syntax errors, show warnings, run tests, generate declarations, and deploy canisters each time you make changes in your code.
+Use [`mops watch`](./cli/4-dev/01-mops-watch.md) to check syntax errors, show warnings, run tests, generate declarations, and deploy canisters each time you make changes in your code.

--- a/docs/docs/01-quick-start.md
+++ b/docs/docs/01-quick-start.md
@@ -43,7 +43,7 @@ Add `mops` as a packtool to your `dfx.json`
 ```
 
 ## 5. Install Motoko Packages
-Use [`mops add`](/cli/mops-add) to install a specific package and save it to `mops.toml`
+Use [`mops add`](./cli/1-deps/01-mops-add.md) to install a specific package and save it to `mops.toml`
 
 ```
 mops add base

--- a/docs/docs/09-mops.toml.md
+++ b/docs/docs/09-mops.toml.md
@@ -44,9 +44,9 @@ Make sure there is no `/tree/main/` in the URL.
 GitHub dependencies are not allowed in `[dependencies]`. Please publish the dependency to the Mops registry instead.
 :::
 
-Learn how Mops resolves dependencies [here](/how-dependency-resolution-works).
+Learn how Mops resolves dependencies [here](./articles/01-how-dependecy-resolution-works.md).
 
-Learn about version pinning [here](/dependency-version-pinning).
+Learn about version pinning [here](./articles/00-dependency-version-pinning.md).
 
 
 ## [dev-dependencies]
@@ -57,13 +57,13 @@ Same structure as `[dependencies]`, with the exception that GitHub dependencies 
 
 
 ## [toolchain]
-See [toolchain management](/cli/toolchain) page for more details.
+See [toolchain management](./cli/5-toolchain/01-toolchain-overview.md) page for more details.
 
 | Field                | Description                                      |
 | -------------------- | ------------------------------------------------ |
 | moc                  | Motoko compiler version (e.g. `1.0.0`) or file path (e.g. `./tools/moc`, `/usr/local/bin/moc`)   |
-| wasmtime             | WASM runtime version (e.g. `41.0.0`) or file path used to run [tests](/cli/mops-test#--mode) in `wasi` mode   |
-| pocket-ic            | Local IC replica version (e.g. `12.0.0`) or file path used to run [benchmarks](/cli/mops-bench#--replica). Versions below `9.0.0` are deprecated and will no longer be supported in mops v3   |
+| wasmtime             | WASM runtime version (e.g. `41.0.0`) or file path used to run [tests](./cli/4-dev/01-mops-test.md#--mode) in `wasi` mode   |
+| pocket-ic            | Local IC replica version (e.g. `12.0.0`) or file path used to run [benchmarks](./cli/4-dev/02-mops-bench.md#--replica). Versions below `9.0.0` are deprecated and will no longer be supported in mops v3   |
 | lintoko              | Linter version (e.g. `0.7.0`) or file path for Motoko linting   |
 | wasm-opt             | Binaryen version (e.g. `131`) or file path used for `[optimize]` post-build Wasm optimization   |
 
@@ -91,7 +91,7 @@ Use `mops moc-args` to print the moc flags defined in `mops.toml` (useful when i
 
 ## [canisters]
 
-Define Motoko canisters for [`mops build`](/cli/mops-build), [`mops check`](/cli/mops-check), and [`mops check-stable`](/cli/mops-check-stable).
+Define Motoko canisters for [`mops build`](./cli/4-dev/03-mops-build.md), [`mops check`](./cli/4-dev/04-mops-check.md), and [`mops check-stable`](./cli/4-dev/05-mops-check-stable.md).
 
 Each canister entry specifies the entrypoint file and optional compiler settings.
 
@@ -125,7 +125,7 @@ main = "src/frontend/main.mo"
 
 ### `[canisters.<name>.check-stable]`
 
-Configure automatic stable variable compatibility checking for a canister. When set, [`mops check`](/cli/mops-check) will verify that the current canister is compatible with the deployed version.
+Configure automatic stable variable compatibility checking for a canister. When set, [`mops check`](./cli/4-dev/04-mops-check.md) will verify that the current canister is compatible with the deployed version.
 
 | Field         | Description                                                     |
 | ------------- | --------------------------------------------------------------- |
@@ -137,19 +137,19 @@ Example:
 path = "deployed/backend.most"
 ```
 
-For a new project with no prior deployment, run [`mops deployed init`](/cli/mops-deployed) — it commits an empty-actor `.most` at the configured path so the check passes against an empty baseline. After every successful deploy, run [`mops deployed`](/cli/mops-deployed) to promote the just-built `.most` into this file.
+For a new project with no prior deployment, run [`mops deployed init`](./cli/4-dev/09-mops-deployed.md) — it commits an empty-actor `.most` at the configured path so the check passes against an empty baseline. After every successful deploy, run [`mops deployed`](./cli/4-dev/09-mops-deployed.md) to promote the just-built `.most` into this file.
 
 ### `[canisters.<name>.migrations]`
 
 Configure managed enhanced migration chains for a canister. When set, `mops check`, `mops build`, and `mops check-stable` auto-inject `--enhanced-migration` for the canister. Create migration files directly in the `chain` directory.
 
-After `mops check --fix` (or `mops check <canister>`) confirms the chain compiles, run [`mops build`](/cli/mops-build) to produce the wasm artifact.
+After `mops check --fix` (or `mops check <canister>`) confirms the chain compiles, run [`mops build`](./cli/4-dev/03-mops-build.md) to produce the wasm artifact.
 
 | Field       | Description                                                     |
 | ----------- | --------------------------------------------------------------- |
 | chain       | Path to the directory containing migration files (required) |
 | check-limit | Max number of recent migrations to pass to `moc` during `mops check` and `mops check-stable`, and to `lintoko` during `mops lint` (optional). Useful when the chain grows long and re-checking every old migration slows feedback down. When set, the stable check reports if more migrations are pending (relative to the deployed `.most` baseline) than the limit allows — as an error if compat failed, otherwise a warning. Override per run with `--no-check-limit` |
-| next        | Path to the directory for a pending migration (optional, **experimental**). Required for the experimental [`mops migrate`](/cli/mops-migrate) workflow. Must contain 0 or 1 `.mo` files. Must share the same parent directory as `chain` |
+| next        | Path to the directory for a pending migration (optional, **experimental**). Required for the experimental [`mops migrate`](./cli/4-dev/08-mops-migrate.md) workflow. Must contain 0 or 1 `.mo` files. Must share the same parent directory as `chain` |
 | build-limit | Max number of recent migrations to pass to `moc` during `mops build` (optional, **experimental**) |
 
 Example:
@@ -180,7 +180,7 @@ backend = "src/main.mo"
 
 ## [build]
 
-Global build settings used by [`mops build`](/cli/mops-build).
+Global build settings used by [`mops build`](./cli/4-dev/03-mops-build.md).
 
 | Field     | Description                                                     |
 | --------- | --------------------------------------------------------------- |
@@ -224,7 +224,7 @@ Pin Binaryen via `[toolchain] wasm-opt` (e.g. `"131"`). If `[optimize]` is set a
 
 If `wasm-opt` fails, mops warns and keeps the unoptimized Wasm (same soft-fail behavior as dfx). Use `--verbose` for full `wasm-opt` output.
 
-Pass `--no-optimize` to [`mops build`](/cli/mops-build#--no-optimize) or [`mops bench`](/cli/mops-bench#--no-optimize) to skip this pass for a single run without editing `mops.toml`.
+Pass `--no-optimize` to [`mops build`](./cli/4-dev/03-mops-build.md#--no-optimize) or [`mops bench`](./cli/4-dev/02-mops-bench.md#--no-optimize) to skip this pass for a single run without editing `mops.toml`.
 
 :::note
 Deploy recipes (e.g. icp-cli) that also run `wasm-opt` should skip that step when mops already optimized the artifact — avoid stacking passes. Actor-class Wasm embedded inside Motoko modules is not recursively optimized.
@@ -233,7 +233,7 @@ Deploy recipes (e.g. icp-cli) that also run `wasm-opt` should skip that step whe
 
 ## [deployed]
 
-Settings for [`mops deployed`](/cli/mops-deployed).
+Settings for [`mops deployed`](./cli/4-dev/09-mops-deployed.md).
 
 | Field | Description                                                                                                                          |
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------ |
@@ -250,7 +250,7 @@ All canisters share one directory; per-canister overrides are not supported.
 
 ## [lint]
 
-Settings for [`mops lint`](/cli/mops-lint).
+Settings for [`mops lint`](./cli/4-dev/07-mops-lint.md).
 
 | Field   | Description                                                                                                                                                                         |
 | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -298,4 +298,4 @@ Use when your package will not work with older versions of the `moc` compiler or
 
 ## Advanced Configuration
 
-For additional configuration options including registry endpoint overrides, see [Environment Variables](/cli/environment-variables).
+For additional configuration options including registry endpoint overrides, see [Environment Variables](./cli/7-misc/06-environment-variables.md).

--- a/docs/docs/articles/02-how-to-version-a-package.md
+++ b/docs/docs/articles/02-how-to-version-a-package.md
@@ -15,7 +15,7 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 2. MINOR version when you add functionality in a backward compatible manner
 3. PATCH version when you make backward compatible bug fixes
 
-[`mops bump`](/cli/mops-bump) command can help you to bump the version of your package.
+[`mops bump`](../cli/2-publish/02-mops-bump.md) command can help you to bump the version of your package.
 
 ### How do I know when to release 1.0.0?
 
@@ -23,4 +23,4 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 - If you have a stable API on which users have come to depend, you should be 1.0.0.
 - If you’re worrying a lot about backward compatibility, you should probably already be 1.0.0.
 
-Also see: [How dependency resolution works](/how-dependency-resolution-works).
+Also see: [How dependency resolution works](./01-how-dependecy-resolution-works.md).

--- a/docs/docs/articles/03-package-owners-and-maintainers.md
+++ b/docs/docs/articles/03-package-owners-and-maintainers.md
@@ -15,6 +15,6 @@ Owners have full control over the package, including the ability to publish new 
 | Add or remove owners | :heavy_check_mark: | :x: |
 | Add or remove maintainers | :heavy_check_mark: | :x: |
 
-Use [`mops owner`](/cli/mops-owner) command to manage owners of a package.
+Use [`mops owner`](../cli/2-publish/05-mops-owner.md) command to manage owners of a package.
 
-Use [`mops maintainer`](/cli/mops-maintainer) command to manage maintainers of a package.
+Use [`mops maintainer`](../cli/2-publish/06-mops-maintainer.md) command to manage maintainers of a package.

--- a/docs/docs/cli/1-deps/01-mops-add.md
+++ b/docs/docs/cli/1-deps/01-mops-add.md
@@ -44,7 +44,7 @@ Add package to `[dev-dependencies]` section.
 
 ### `--lock`
 
-What to do with the [lockfile](/mops.lock)
+What to do with the [lockfile](../../10-mops.lock.md)
 
 Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 

--- a/docs/docs/cli/1-deps/01-mops-remove.md
+++ b/docs/docs/cli/1-deps/01-mops-remove.md
@@ -20,7 +20,7 @@ Remove package from `[dev-dependencies]` section.
 
 ### `--lock`
 
-What to do with the [lockfile](/mops.lock).
+What to do with the [lockfile](../../10-mops.lock.md).
 
 Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 

--- a/docs/docs/cli/1-deps/02-mops-install.md
+++ b/docs/docs/cli/1-deps/02-mops-install.md
@@ -17,13 +17,13 @@ The lockfile is considered **up to date** when the `[dependencies]` and `[dev-de
 - **Lockfile up to date** — installs the exact versions recorded in the lockfile, skipping dependency resolution.
 - **Lockfile missing or out of date** — runs full dependency resolution, installs resolved versions, then creates/updates the lockfile.
 
-See [mops.lock](/mops.lock) for details on lockfile contents and when to commit it.
+See [mops.lock](../../10-mops.lock.md) for details on lockfile contents and when to commit it.
 
 ## Options
 
 ### `--lock`
 
-What to do with the [lockfile](/mops.lock).
+What to do with the [lockfile](../../10-mops.lock.md).
 
 Possible values:
 - `update` — keep the lockfile in sync with current dependencies and verify file integrity (default outside CI). Pass explicitly to force regeneration if the lockfile is stale or corrupt.
@@ -46,4 +46,4 @@ Note: explicit `--lock check` also errors when the lock is missing; the deprecat
 
 `mops add`, `mops remove`, `mops update`, and `mops sync` are unaffected — they always default to updating the lockfile.
 
-See [CI environments](/mops.lock#ci-environments) on the mops.lock page for full details.
+See [CI environments](../../10-mops.lock.md#ci-environments) on the mops.lock page for full details.

--- a/docs/docs/cli/1-deps/03-mops-outdated.md
+++ b/docs/docs/cli/1-deps/03-mops-outdated.md
@@ -14,14 +14,14 @@ mops outdated
 
 ### `--major`
 
-Also report updates that cross the caret bound. Mirrors [`mops update --major`](/cli/mops-update#--major).
+Also report updates that cross the caret bound. Mirrors [`mops update --major`](./04-mops-update.md#--major).
 ```
 mops outdated --major
 ```
 
 ### `--patch`
 
-Restrict reported updates to patch versions only. Mirrors [`mops update --patch`](/cli/mops-update#--patch).
+Restrict reported updates to patch versions only. Mirrors [`mops update --patch`](./04-mops-update.md#--patch).
 ```
 mops outdated --patch
 ```

--- a/docs/docs/cli/1-deps/04-mops-update.md
+++ b/docs/docs/cli/1-deps/04-mops-update.md
@@ -44,7 +44,7 @@ Mutually exclusive with [`--major`](#--major).
 
 ### `--lock`
 
-What to do with the [lockfile](/mops.lock).
+What to do with the [lockfile](../../10-mops.lock.md).
 
 Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 

--- a/docs/docs/cli/1-deps/05-mops-sync.md
+++ b/docs/docs/cli/1-deps/05-mops-sync.md
@@ -17,7 +17,7 @@ mops sync
 
 ### `--lock`
 
-What to do with the [lockfile](/mops.lock).
+What to do with the [lockfile](../../10-mops.lock.md).
 
 Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 

--- a/docs/docs/cli/2-publish/01-mops-publish.md
+++ b/docs/docs/cli/2-publish/01-mops-publish.md
@@ -10,7 +10,7 @@ Publish package to the mops registry
 mops publish
 ```
 
-You need to [import identity](/cli/mops-user-import) before publishing a package.
+You need to [import identity](../3-user/01-mops-user-import.md) before publishing a package.
 
 Tests will be run before publishing to ensure the package works correctly.
 

--- a/docs/docs/cli/2-publish/05-mops-owner.md
+++ b/docs/docs/cli/2-publish/05-mops-owner.md
@@ -8,7 +8,7 @@ sidebar_label: mops owner
 List, add or remove owners of a package.
 
 :::info
-Check the [Package owners and maintainers](/package-owners-and-maintainers) for more information.
+Check the [Package owners and maintainers](../../articles/03-package-owners-and-maintainers.md) for more information.
 :::
 
 ## `mops owner`

--- a/docs/docs/cli/2-publish/06-mops-maintainer.md
+++ b/docs/docs/cli/2-publish/06-mops-maintainer.md
@@ -8,7 +8,7 @@ sidebar_label: mops maintainer
 List, add or remove  maintainers of a package.
 
 :::info
-Check the [Package owners and maintainers](/package-owners-and-maintainers) for more information.
+Check the [Package owners and maintainers](../../articles/03-package-owners-and-maintainers.md) for more information.
 :::
 
 ## `mops maintainer`

--- a/docs/docs/cli/4-dev/02-mops-bench.md
+++ b/docs/docs/cli/4-dev/02-mops-bench.md
@@ -30,7 +30,7 @@ Under the hood, Mops will:
 
 The number you get is for the exact wasm the chosen replica runs, and the two replicas install it differently:
 
-- **With [`[optimize]`](/mops.toml#optimize)** — `mops bench` runs `wasm-opt` on the module before deploy (same pass as `mops build`). Prefer this when you want bench numbers to match an optimized deploy artifact. When that pass **succeeds**, the deprecated `dfx` replica path does **not** apply a second `optimize: "cycles"` pass (on soft-fail, dfx still may). Pass [`--no-optimize`](#--no-optimize) to skip the `wasm-opt` pass for a single run without editing `mops.toml`.
+- **With [`[optimize]`](../../09-mops.toml.md#optimize)** — `mops bench` runs `wasm-opt` on the module before deploy (same pass as `mops build`). Prefer this when you want bench numbers to match an optimized deploy artifact. When that pass **succeeds**, the deprecated `dfx` replica path does **not** apply a second `optimize: "cycles"` pass (on soft-fail, dfx still may). Pass [`--no-optimize`](#--no-optimize) to skip the `wasm-opt` pass for a single run without editing `mops.toml`.
 - **Without `[optimize]`**:
   - **`pocket-ic`** runs the raw `moc` output — **no optimization**.
   - **`dfx`** post-optimizes before install (`optimize: "cycles"`, via `ic-wasm`), so instruction counts can be lower — and that path fails on EOP Motoko (Table64), falling back to unoptimized Wasm.
@@ -89,7 +89,7 @@ Use it to measure a canister that still uses legacy persistence. Has no effect w
 
 ### `--no-optimize`
 
-Skip the [`[optimize]`](/mops.toml#optimize) `wasm-opt` pass for this run, even when it is configured in `mops.toml`. Has no effect when `[optimize]` is not set. The `dfx` replica may still apply its own `optimize: "cycles"` pass on deploy — only the `pocket-ic` replica then runs the raw `moc` output.
+Skip the [`[optimize]`](../../09-mops.toml.md#optimize) `wasm-opt` pass for this run, even when it is configured in `mops.toml`. Has no effect when `[optimize]` is not set. The `dfx` replica may still apply its own `optimize: "cycles"` pass on deploy — only the `pocket-ic` replica then runs the raw `moc` output.
 
 ```
 mops bench --no-optimize

--- a/docs/docs/cli/4-dev/03-mops-build.md
+++ b/docs/docs/cli/4-dev/03-mops-build.md
@@ -23,7 +23,7 @@ For each canister, three files are written to the output directory (default `.mo
 
 If the canister config sets a `candid` field, the generated `.did` is also checked for compatibility against it.
 
-When [`[optimize]`](/mops.toml#optimize) is set in `mops.toml`, mops runs Binaryen `wasm-opt` on the Wasm **after** candid metadata is embedded. Defaults are `-O3 -g` (see the config reference). Failures warn and leave the unoptimized module. Pass [`--no-optimize`](#--no-optimize) to skip this pass for a single run.
+When [`[optimize]`](../../09-mops.toml.md#optimize) is set in `mops.toml`, mops runs Binaryen `wasm-opt` on the Wasm **after** candid metadata is embedded. Defaults are `-O3 -g` (see the config reference). Failures warn and leave the unoptimized module. Pass [`--no-optimize`](#--no-optimize) to skip this pass for a single run.
 
 ### Examples
 
@@ -70,7 +70,7 @@ mops build --output ./dist
 
 ### `--no-optimize`
 
-Skip the [`[optimize]`](/mops.toml#optimize) `wasm-opt` post-pass for this run, even when it is configured in `mops.toml`. Has no effect when `[optimize]` is not set. Useful for a faster build or to produce an unoptimized module for debugging without editing `mops.toml`.
+Skip the [`[optimize]`](../../09-mops.toml.md#optimize) `wasm-opt` post-pass for this run, even when it is configured in `mops.toml`. Has no effect when `[optimize]` is not set. Useful for a faster build or to produce an unoptimized module for debugging without editing `mops.toml`.
 
 ```
 mops build --no-optimize
@@ -111,7 +111,7 @@ The `--output` CLI flag takes precedence over this config value.
 
 When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops build` automatically injects the `--enhanced-migration` flag. The full migration chain is compiled into the WASM.
 
-If `mops check` passes but `mops build` fails while [`check-limit`](/cli/mops-migrate#chain-trimming) is set, re-run `mops check --no-check-limit` to surface the issue — `check` trims the chain, while `build` compiles all of it.
+If `mops check` passes but `mops build` fails while [`check-limit`](./08-mops-migrate.md#chain-trimming) is set, re-run `mops check --no-check-limit` to surface the issue — `check` trims the chain, while `build` compiles all of it.
 
 ## Candid Compatibility
 
@@ -119,7 +119,7 @@ If a `candid` field is specified in the canister configuration, the build comman
 
 If the compatibility check fails, the build will fail with an error message.
 
-For manual compatibility checking, see [`mops check-candid`](/cli/mops-check-candid).
+For manual compatibility checking, see [`mops check-candid`](./06-mops-check-candid.md).
 
 ## Stable Types
 
@@ -134,4 +134,4 @@ path = ".deployed/backend.most"
 
 With this in place, `mops check` automatically verifies upgrade compatibility on every run.
 
-See [`mops check`](/cli/mops-check#stable-compatibility-checking) for full configuration details.
+See [`mops check`](./04-mops-check.md#stable-compatibility-checking) for full configuration details.

--- a/docs/docs/cli/4-dev/04-mops-check.md
+++ b/docs/docs/cli/4-dev/04-mops-check.md
@@ -85,7 +85,7 @@ Print the full `moc` invocation before running it.
 
 ### `--no-check-limit`
 
-Use the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. Useful with `--fix` to autofix issues in older migrations that the limit would normally skip. Also suppresses the pending-migration warning that runs when `check-limit` is set. See [chain trimming](/cli/mops-migrate#chain-trimming).
+Use the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. Useful with `--fix` to autofix issues in older migrations that the limit would normally skip. Also suppresses the pending-migration warning that runs when `check-limit` is set. See [chain trimming](./08-mops-migrate.md#chain-trimming).
 
 ```
 mops check --fix --no-check-limit
@@ -100,7 +100,7 @@ mops check -- -Werror
 ```
 
 :::tip
-Global `moc` flags can be configured in `mops.toml` under `[moc].args` so they don't need to be passed on every invocation. See [`mops.toml` reference](/mops.toml#moc).
+Global `moc` flags can be configured in `mops.toml` under `[moc].args` so they don't need to be passed on every invocation. See [`mops.toml` reference](../../09-mops.toml.md#moc).
 :::
 
 ## Stable compatibility checking
@@ -122,9 +122,9 @@ If the file at `path` doesn't exist, the check fails with an error. For initial 
 actor { };
 ```
 
-For more details, see [`mops check-stable`](/cli/mops-check-stable).
+For more details, see [`mops check-stable`](./05-mops-check-stable.md).
 
-When `[canisters.<name>.migrations].check-limit` is set, the stable check compares the deployed `.most` baseline against the local chain after compatibility checking. If more migrations are pending than `check-limit` allows, mops reports a diagnostic naming the latest pending file to fold into. If compat already failed, this replaces the misleading `moc` error; if compat passed anyway, it is shown as a warning. Only applies when the baseline is a committed `.most` file configured via `[check-stable].path` (not a `.mo` source passed on the command line). See [chain trimming](/cli/mops-migrate#chain-trimming).
+When `[canisters.<name>.migrations].check-limit` is set, the stable check compares the deployed `.most` baseline against the local chain after compatibility checking. If more migrations are pending than `check-limit` allows, mops reports a diagnostic naming the latest pending file to fold into. If compat already failed, this replaces the misleading `moc` error; if compat passed anyway, it is shown as a warning. Only applies when the baseline is a committed `.most` file configured via `[check-stable].path` (not a `.mo` source passed on the command line). See [chain trimming](./08-mops-migrate.md#chain-trimming).
 
 ## Enhanced migration support
 
@@ -134,7 +134,7 @@ If a stable compatibility check fails and `[migrations]` is configured, a hint i
 
 ## Lint integration
 
-After type-checking succeeds, `mops check` automatically runs [`mops lint`](/cli/mops-lint) when `lintoko` is pinned in `[toolchain]`.
+After type-checking succeeds, `mops check` automatically runs [`mops lint`](./07-mops-lint.md) when `lintoko` is pinned in `[toolchain]`.
 
 This means `mops check` is the single command for all correctness checks — type errors and lint violations are both caught in one pass.
 
@@ -149,5 +149,5 @@ When file paths are passed explicitly (e.g. `mops check src/Main.mo`), linting i
 :::
 
 :::info
-`mops check` only type-checks files — it does not produce any compiled output. To compile canisters, use [`mops build`](/cli/mops-build).
+`mops check` only type-checks files — it does not produce any compiled output. To compile canisters, use [`mops build`](./03-mops-build.md).
 :::

--- a/docs/docs/cli/4-dev/05-mops-check-stable.md
+++ b/docs/docs/cli/4-dev/05-mops-check-stable.md
@@ -76,7 +76,7 @@ mops check-stable <old-file> [canister]
 - **`[canister]`** — Name of the canister to check against. When omitted, auto-detected if exactly one canister is defined; errors if multiple canisters exist.
 
 :::tip
-`mops build` generates a `.most` file for each canister alongside `.wasm` and `.did`. Use [`mops deployed`](/cli/mops-deployed) as a post-deploy hook to promote that `.most` into a committed `deployed/<name>.most` baseline, and configure `[canisters.<name>.check-stable]` in `mops.toml` so `mops check-stable` (and `mops check`) verify upgrade safety automatically on every run.
+`mops build` generates a `.most` file for each canister alongside `.wasm` and `.did`. Use [`mops deployed`](./09-mops-deployed.md) as a post-deploy hook to promote that `.most` into a committed `deployed/<name>.most` baseline, and configure `[canisters.<name>.check-stable]` in `mops.toml` so `mops check-stable` (and `mops check`) verify upgrade safety automatically on every run.
 :::
 
 ## Options
@@ -87,7 +87,7 @@ Show detailed output including the `moc` commands being run and the intermediate
 
 ### `--no-check-limit`
 
-Use the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. See [chain trimming](/cli/mops-migrate#chain-trimming). Also suppresses the pending-migration warning that runs when `check-limit` is set.
+Use the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. See [chain trimming](./08-mops-migrate.md#chain-trimming). Also suppresses the pending-migration warning that runs when `check-limit` is set.
 
 ## Pending migration diagnostic
 
@@ -108,5 +108,5 @@ mops check-stable -- --experimental-stable-memory=1
 ```
 
 :::tip
-Global `moc` flags configured in `[moc].args` and per-canister flags in `[canisters.<name>].args` are automatically applied. See [`mops.toml` reference](/mops.toml#moc).
+Global `moc` flags configured in `[moc].args` and per-canister flags in `[canisters.<name>].args` are automatically applied. See [`mops.toml` reference](../../09-mops.toml.md#moc).
 :::

--- a/docs/docs/cli/4-dev/06-mops-check-candid.md
+++ b/docs/docs/cli/4-dev/06-mops-check-candid.md
@@ -48,5 +48,5 @@ Breaking changes:
 - Make optional parameters required
 
 :::info
-The [`mops build`](/cli/mops-build) command automatically runs Candid compatibility checks when a `candid` field is specified in the canister configuration.
+The [`mops build`](./03-mops-build.md) command automatically runs Candid compatibility checks when a `candid` field is specified in the canister configuration.
 :::

--- a/docs/docs/cli/4-dev/07-mops-lint.md
+++ b/docs/docs/cli/4-dev/07-mops-lint.md
@@ -64,7 +64,7 @@ mops lint --rules ./rules-a --rules ./rules-b
 
 ### `--no-check-limit`
 
-Lint the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. See [chain trimming](/cli/mops-migrate#chain-trimming).
+Lint the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. See [chain trimming](./08-mops-migrate.md#chain-trimming).
 
 ## Configuration
 
@@ -158,4 +158,4 @@ my-package/
 
 Exits with a non-zero code if any lint errors are found.
 
-See also: [toolchain management](/cli/toolchain) to pin a `lintoko` version.
+See also: [toolchain management](../5-toolchain/01-toolchain-overview.md) to pin a `lintoko` version.

--- a/docs/docs/cli/4-dev/08-mops-migrate.md
+++ b/docs/docs/cli/4-dev/08-mops-migrate.md
@@ -6,7 +6,7 @@ sidebar_label: mops migrate
 # `mops migrate`
 
 :::warning Experimental
-`mops migrate` is **experimental** and not recommended for general use yet — its commands and configuration may change. The recommended workflow is to create migration files directly in your `chain` directory; see [`[canisters.<name>.migrations]`](/mops.toml#canistersnamemigrations).
+`mops migrate` is **experimental** and not recommended for general use yet — its commands and configuration may change. The recommended workflow is to create migration files directly in your `chain` directory; see [`[canisters.<name>.migrations]`](../../09-mops.toml.md#canistersnamemigrations).
 :::
 
 Manage enhanced migration chains.
@@ -67,7 +67,7 @@ build-limit = 100
 
 `moc` diagnostics may point to a staged path under `.migrations-<canister>/`, which mops removes when the command finishes.
 
-See [`mops.toml` reference](/mops.toml#canistersnamemigrations) for all fields.
+See [`mops.toml` reference](../../09-mops.toml.md#canistersnamemigrations) for all fields.
 
 ## Typical workflow
 

--- a/docs/docs/cli/4-dev/09-mops-deployed.md
+++ b/docs/docs/cli/4-dev/09-mops-deployed.md
@@ -5,7 +5,7 @@ sidebar_label: mops deployed
 
 # `mops deployed`
 
-Post-deploy hook: promote the just-built `.most` stable-types file into a committed `deployed/` directory so [`mops check-stable`](/cli/mops-check-stable) compares against the deployed version on the next build.
+Post-deploy hook: promote the just-built `.most` stable-types file into a committed `deployed/` directory so [`mops check-stable`](./05-mops-check-stable.md) compares against the deployed version on the next build.
 
 ```
 mops deployed [canisters...]      # promote .most → deployed/
@@ -14,7 +14,7 @@ mops deployed init [canisters...] # one-time bootstrap: empty-actor baseline + w
 
 Run `mops deployed` after a successful deploy. It does **not** read from chain or wasm metadata — it only copies the local `.most` left by `mops build` into the project's `deployed/` directory so the on-disk stable-check baseline always matches the wasm you just deployed.
 
-For canister selection rules, see [`mops build`](/cli/mops-build).
+For canister selection rules, see [`mops build`](./03-mops-build.md).
 
 ## Lifecycle
 

--- a/docs/docs/cli/5-toolchain/01-toolchain-overview.md
+++ b/docs/docs/cli/5-toolchain/01-toolchain-overview.md
@@ -14,13 +14,13 @@ When you run `mops install` command, Mops will install the specified version of 
 - `wasmtime` - Wasmtime runtime (used by `mops test --mode wasi`)
 - `pocket-ic` - PocketIC replica (used by `mops bench --replica pocket-ic`). Versions below `9.0.0` are deprecated and will no longer be supported in mops v3.
 - `lintoko` - Extensible linter for Motoko ([https://github.com/caffeinelabs/lintoko](https://github.com/caffeinelabs/lintoko))
-- `wasm-opt` - Binaryen Wasm optimizer (used when [`[optimize]`](/mops.toml#optimize) is set)
+- `wasm-opt` - Binaryen Wasm optimizer (used when [`[optimize]`](../../09-mops.toml.md#optimize) is set)
 
 ## Specifying tool versions
 
 ### Option 1: Use `mops toolchain use` command
 
-You can use [`mops toolchain use`](/cli/mops-toolchain-use) command to install specific tool version and update `mops.toml` file.
+You can use [`mops toolchain use`](./03-mops-toolchain-use.md) command to install specific tool version and update `mops.toml` file.
 ```
 mops toolchain use moc 0.10.3
 mops toolchain use wasmtime 16.0.0
@@ -65,9 +65,9 @@ lintoko = "../custom-lintoko/bin/lintoko"
 
 ## Toolchain management commands
 
-- [`mops toolchain init`](/cli/mops-toolchain-init)
-- [`mops toolchain use`](/cli/mops-toolchain-use)
-- [`mops toolchain update`](/cli/mops-toolchain-update)
-- [`mops toolchain info`](/cli/mops-toolchain-info)
-- [`mops toolchain bin`](/cli/mops-toolchain-bin)
-- [`mops toolchain reset`](/cli/mops-toolchain-reset)
+- [`mops toolchain init`](./02-mops-toolchain-init.md)
+- [`mops toolchain use`](./03-mops-toolchain-use.md)
+- [`mops toolchain update`](./04-mops-toolchain-update.md)
+- [`mops toolchain info`](./07-mops-toolchain-info.md)
+- [`mops toolchain bin`](./05-mops-toolchain-bin.md)
+- [`mops toolchain reset`](./06-mops-toolchain-rest.md)

--- a/docs/docs/cli/5-toolchain/02-mops-toolchain-init.md
+++ b/docs/docs/cli/5-toolchain/02-mops-toolchain-init.md
@@ -24,4 +24,4 @@ In CI environment, this command runs automatically when you run `mops install` o
 So no need to run it manually in GitHub Actions.
 :::
 
-To undo changes made by this command, run [`mops toolchain reset`](/cli/mops-toolchain-reset) command.
+To undo changes made by this command, run [`mops toolchain reset`](./06-mops-toolchain-rest.md) command.

--- a/docs/docs/cli/5-toolchain/06-mops-toolchain-rest.md
+++ b/docs/docs/cli/5-toolchain/06-mops-toolchain-rest.md
@@ -11,4 +11,4 @@ Uninstall toolchain management.
 mops toolchain reset
 ```
 
-This command will undo changes made by [`mops toolchain init`](/cli/mops-toolchain-init) command.
+This command will undo changes made by [`mops toolchain init`](./02-mops-toolchain-init.md) command.

--- a/docs/docs/cli/7-misc/03-mops-cache.md
+++ b/docs/docs/cli/7-misc/03-mops-cache.md
@@ -11,7 +11,7 @@ When you run `mops install`, `mops add <pkg>` or `mops toolchain use/update`, Mo
 
 Local cache directory is created in the project root in the `.mops` directory.
 
-The integrity of cached files is verified using the [mops.lock](/mops.lock) file.
+The integrity of cached files is verified using the [mops.lock](../../10-mops.lock.md) file.
 
 ### `mops cache show`
 

--- a/docs/docs/cli/7-misc/05-mops-moc-args.md
+++ b/docs/docs/cli/7-misc/05-mops-moc-args.md
@@ -29,4 +29,4 @@ $ mops moc-args
 
 Each flag is printed on its own line.
 
-See also: [`[moc]` config section](/mops.toml#moc).
+See also: [`[moc]` config section](../../09-mops.toml.md#moc).

--- a/docs/versioned_docs/version-2.x/00-introduction.md
+++ b/docs/versioned_docs/version-2.x/00-introduction.md
@@ -9,7 +9,7 @@ Mops aims to be a one-stop solution for all your Motoko development needs.
 
 Mops empowers and simplifies Motoko developer experience.
 
-Learn how to start using Mops in [Quick Start](/quick-start).
+Learn how to start using Mops in [Quick Start](./01-quick-start.md).
 
 ## What is Mops?
 
@@ -27,16 +27,16 @@ You can discover Motoko packages on [mops.one](https://mops.one/).
 
 ### Mops is a test runner for Motoko
 
-Mops comes with a [test runner](/cli/mops-test) that follows [Mops Message Format](https://github.com/caffeinelabs/mops-message-format) and works with the [`test` package](https://mops.one/test).
+Mops comes with a [test runner](./cli/4-dev/01-mops-test.md) that follows [Mops Message Format](https://github.com/caffeinelabs/mops-message-format) and works with the [`test` package](https://mops.one/test).
 
 ### Mops is a benchmarking tool for Motoko
 
-Mops comes with a [benchmarking tool](/cli/mops-bench) that works with the [`bench` package](https://mops.one/bench).
+Mops comes with a [benchmarking tool](./cli/4-dev/02-mops-bench.md) that works with the [`bench` package](https://mops.one/bench).
 
 ### Mops is a toolchain manager for Motoko
 
-[`mops toolchain`](/cli/toolchain) helps you install and manage Motoko toolchain, including `moc`, `pocket-ic`, `wasmtime`, and `lintoko`.
+[`mops toolchain`](./cli/5-toolchain/01-toolchain-overview.md) helps you install and manage Motoko toolchain, including `moc`, `pocket-ic`, `wasmtime`, and `lintoko`.
 
 ### Mops is an essential tool for Motoko developers
 
-Use [`mops watch`](/cli/mops-watch) to check syntax errors, show warnings, run tests, generate declarations, and deploy canisters each time you make changes in your code.
+Use [`mops watch`](./cli/4-dev/01-mops-watch.md) to check syntax errors, show warnings, run tests, generate declarations, and deploy canisters each time you make changes in your code.

--- a/docs/versioned_docs/version-2.x/01-quick-start.md
+++ b/docs/versioned_docs/version-2.x/01-quick-start.md
@@ -43,7 +43,7 @@ Add `mops` as a packtool to your `dfx.json`
 ```
 
 ## 5. Install Motoko Packages
-Use [`mops add`](/cli/mops-add) to install a specific package and save it to `mops.toml`
+Use [`mops add`](./cli/1-deps/01-mops-add.md) to install a specific package and save it to `mops.toml`
 
 ```
 mops add base

--- a/docs/versioned_docs/version-2.x/09-mops.toml.md
+++ b/docs/versioned_docs/version-2.x/09-mops.toml.md
@@ -44,9 +44,9 @@ Make sure there is no `/tree/main/` in the URL.
 GitHub dependencies are not allowed in `[dependencies]`. Please publish the dependency to the Mops registry instead.
 :::
 
-Learn how Mops resolves dependencies [here](/how-dependency-resolution-works).
+Learn how Mops resolves dependencies [here](./articles/01-how-dependecy-resolution-works.md).
 
-Learn about version pinning [here](/dependency-version-pinning).
+Learn about version pinning [here](./articles/00-dependency-version-pinning.md).
 
 
 ## [dev-dependencies]
@@ -57,13 +57,13 @@ Same structure as `[dependencies]`, with the exception that GitHub dependencies 
 
 
 ## [toolchain]
-See [toolchain management](/cli/toolchain) page for more details.
+See [toolchain management](./cli/5-toolchain/01-toolchain-overview.md) page for more details.
 
 | Field                | Description                                      |
 | -------------------- | ------------------------------------------------ |
 | moc                  | Motoko compiler version (e.g. `1.0.0`) or file path (e.g. `./tools/moc`, `/usr/local/bin/moc`)   |
-| wasmtime             | WASM runtime version (e.g. `41.0.0`) or file path used to run [tests](/cli/mops-test#--mode) in `wasi` mode   |
-| pocket-ic            | Local IC replica version (e.g. `12.0.0`) or file path used to run [benchmarks](/cli/mops-bench#--replica). Versions below `9.0.0` are deprecated and will no longer be supported in mops v3   |
+| wasmtime             | WASM runtime version (e.g. `41.0.0`) or file path used to run [tests](./cli/4-dev/01-mops-test.md#--mode) in `wasi` mode   |
+| pocket-ic            | Local IC replica version (e.g. `12.0.0`) or file path used to run [benchmarks](./cli/4-dev/02-mops-bench.md#--replica). Versions below `9.0.0` are deprecated and will no longer be supported in mops v3   |
 | lintoko              | Linter version (e.g. `0.7.0`) or file path for Motoko linting   |
 | wasm-opt             | Binaryen version (e.g. `131`) or file path used for `[optimize]` post-build Wasm optimization   |
 
@@ -91,7 +91,7 @@ Use `mops moc-args` to print the moc flags defined in `mops.toml` (useful when i
 
 ## [canisters]
 
-Define Motoko canisters for [`mops build`](/cli/mops-build), [`mops check`](/cli/mops-check), and [`mops check-stable`](/cli/mops-check-stable).
+Define Motoko canisters for [`mops build`](./cli/4-dev/03-mops-build.md), [`mops check`](./cli/4-dev/04-mops-check.md), and [`mops check-stable`](./cli/4-dev/05-mops-check-stable.md).
 
 Each canister entry specifies the entrypoint file and optional compiler settings.
 
@@ -125,7 +125,7 @@ main = "src/frontend/main.mo"
 
 ### `[canisters.<name>.check-stable]`
 
-Configure automatic stable variable compatibility checking for a canister. When set, [`mops check`](/cli/mops-check) will verify that the current canister is compatible with the deployed version.
+Configure automatic stable variable compatibility checking for a canister. When set, [`mops check`](./cli/4-dev/04-mops-check.md) will verify that the current canister is compatible with the deployed version.
 
 | Field         | Description                                                     |
 | ------------- | --------------------------------------------------------------- |
@@ -137,19 +137,19 @@ Example:
 path = "deployed/backend.most"
 ```
 
-For a new project with no prior deployment, run [`mops deployed init`](/cli/mops-deployed) — it commits an empty-actor `.most` at the configured path so the check passes against an empty baseline. After every successful deploy, run [`mops deployed`](/cli/mops-deployed) to promote the just-built `.most` into this file.
+For a new project with no prior deployment, run [`mops deployed init`](./cli/4-dev/09-mops-deployed.md) — it commits an empty-actor `.most` at the configured path so the check passes against an empty baseline. After every successful deploy, run [`mops deployed`](./cli/4-dev/09-mops-deployed.md) to promote the just-built `.most` into this file.
 
 ### `[canisters.<name>.migrations]`
 
 Configure managed enhanced migration chains for a canister. When set, `mops check`, `mops build`, and `mops check-stable` auto-inject `--enhanced-migration` for the canister. Create migration files directly in the `chain` directory.
 
-After `mops check --fix` (or `mops check <canister>`) confirms the chain compiles, run [`mops build`](/cli/mops-build) to produce the wasm artifact.
+After `mops check --fix` (or `mops check <canister>`) confirms the chain compiles, run [`mops build`](./cli/4-dev/03-mops-build.md) to produce the wasm artifact.
 
 | Field       | Description                                                     |
 | ----------- | --------------------------------------------------------------- |
 | chain       | Path to the directory containing migration files (required) |
 | check-limit | Max number of recent migrations to pass to `moc` during `mops check` and `mops check-stable`, and to `lintoko` during `mops lint` (optional). Useful when the chain grows long and re-checking every old migration slows feedback down. When set, the stable check reports if more migrations are pending (relative to the deployed `.most` baseline) than the limit allows — as an error if compat failed, otherwise a warning. Override per run with `--no-check-limit` |
-| next        | Path to the directory for a pending migration (optional, **experimental**). Required for the experimental [`mops migrate`](/cli/mops-migrate) workflow. Must contain 0 or 1 `.mo` files. Must share the same parent directory as `chain` |
+| next        | Path to the directory for a pending migration (optional, **experimental**). Required for the experimental [`mops migrate`](./cli/4-dev/08-mops-migrate.md) workflow. Must contain 0 or 1 `.mo` files. Must share the same parent directory as `chain` |
 | build-limit | Max number of recent migrations to pass to `moc` during `mops build` (optional, **experimental**) |
 
 Example:
@@ -180,7 +180,7 @@ backend = "src/main.mo"
 
 ## [build]
 
-Global build settings used by [`mops build`](/cli/mops-build).
+Global build settings used by [`mops build`](./cli/4-dev/03-mops-build.md).
 
 | Field     | Description                                                     |
 | --------- | --------------------------------------------------------------- |
@@ -224,7 +224,7 @@ Pin Binaryen via `[toolchain] wasm-opt` (e.g. `"131"`). If `[optimize]` is set a
 
 If `wasm-opt` fails, mops warns and keeps the unoptimized Wasm (same soft-fail behavior as dfx). Use `--verbose` for full `wasm-opt` output.
 
-Pass `--no-optimize` to [`mops build`](/cli/mops-build#--no-optimize) or [`mops bench`](/cli/mops-bench#--no-optimize) to skip this pass for a single run without editing `mops.toml`.
+Pass `--no-optimize` to [`mops build`](./cli/4-dev/03-mops-build.md#--no-optimize) or [`mops bench`](./cli/4-dev/02-mops-bench.md#--no-optimize) to skip this pass for a single run without editing `mops.toml`.
 
 :::note
 Deploy recipes (e.g. icp-cli) that also run `wasm-opt` should skip that step when mops already optimized the artifact — avoid stacking passes. Actor-class Wasm embedded inside Motoko modules is not recursively optimized.
@@ -233,7 +233,7 @@ Deploy recipes (e.g. icp-cli) that also run `wasm-opt` should skip that step whe
 
 ## [deployed]
 
-Settings for [`mops deployed`](/cli/mops-deployed).
+Settings for [`mops deployed`](./cli/4-dev/09-mops-deployed.md).
 
 | Field | Description                                                                                                                          |
 | ----- | ------------------------------------------------------------------------------------------------------------------------------------ |
@@ -250,7 +250,7 @@ All canisters share one directory; per-canister overrides are not supported.
 
 ## [lint]
 
-Settings for [`mops lint`](/cli/mops-lint).
+Settings for [`mops lint`](./cli/4-dev/07-mops-lint.md).
 
 | Field   | Description                                                                                                                                                                         |
 | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -298,4 +298,4 @@ Use when your package will not work with older versions of the `moc` compiler or
 
 ## Advanced Configuration
 
-For additional configuration options including registry endpoint overrides, see [Environment Variables](/cli/environment-variables).
+For additional configuration options including registry endpoint overrides, see [Environment Variables](./cli/7-misc/06-environment-variables.md).

--- a/docs/versioned_docs/version-2.x/articles/02-how-to-version-a-package.md
+++ b/docs/versioned_docs/version-2.x/articles/02-how-to-version-a-package.md
@@ -15,7 +15,7 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 2. MINOR version when you add functionality in a backward compatible manner
 3. PATCH version when you make backward compatible bug fixes
 
-[`mops bump`](/cli/mops-bump) command can help you to bump the version of your package.
+[`mops bump`](../cli/2-publish/02-mops-bump.md) command can help you to bump the version of your package.
 
 ### How do I know when to release 1.0.0?
 
@@ -23,4 +23,4 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 - If you have a stable API on which users have come to depend, you should be 1.0.0.
 - If you’re worrying a lot about backward compatibility, you should probably already be 1.0.0.
 
-Also see: [How dependency resolution works](/how-dependency-resolution-works).
+Also see: [How dependency resolution works](./01-how-dependecy-resolution-works.md).

--- a/docs/versioned_docs/version-2.x/articles/03-package-owners-and-maintainers.md
+++ b/docs/versioned_docs/version-2.x/articles/03-package-owners-and-maintainers.md
@@ -15,6 +15,6 @@ Owners have full control over the package, including the ability to publish new 
 | Add or remove owners | :heavy_check_mark: | :x: |
 | Add or remove maintainers | :heavy_check_mark: | :x: |
 
-Use [`mops owner`](/cli/mops-owner) command to manage owners of a package.
+Use [`mops owner`](../cli/2-publish/05-mops-owner.md) command to manage owners of a package.
 
-Use [`mops maintainer`](/cli/mops-maintainer) command to manage maintainers of a package.
+Use [`mops maintainer`](../cli/2-publish/06-mops-maintainer.md) command to manage maintainers of a package.

--- a/docs/versioned_docs/version-2.x/cli/1-deps/01-mops-add.md
+++ b/docs/versioned_docs/version-2.x/cli/1-deps/01-mops-add.md
@@ -44,7 +44,7 @@ Add package to `[dev-dependencies]` section.
 
 ### `--lock`
 
-What to do with the [lockfile](/mops.lock)
+What to do with the [lockfile](../../10-mops.lock.md)
 
 Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 

--- a/docs/versioned_docs/version-2.x/cli/1-deps/01-mops-remove.md
+++ b/docs/versioned_docs/version-2.x/cli/1-deps/01-mops-remove.md
@@ -20,7 +20,7 @@ Remove package from `[dev-dependencies]` section.
 
 ### `--lock`
 
-What to do with the [lockfile](/mops.lock).
+What to do with the [lockfile](../../10-mops.lock.md).
 
 Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 

--- a/docs/versioned_docs/version-2.x/cli/1-deps/02-mops-install.md
+++ b/docs/versioned_docs/version-2.x/cli/1-deps/02-mops-install.md
@@ -17,13 +17,13 @@ The lockfile is considered **up to date** when the `[dependencies]` and `[dev-de
 - **Lockfile up to date** — installs the exact versions recorded in the lockfile, skipping dependency resolution.
 - **Lockfile missing or out of date** — runs full dependency resolution, installs resolved versions, then creates/updates the lockfile.
 
-See [mops.lock](/mops.lock) for details on lockfile contents and when to commit it.
+See [mops.lock](../../10-mops.lock.md) for details on lockfile contents and when to commit it.
 
 ## Options
 
 ### `--lock`
 
-What to do with the [lockfile](/mops.lock).
+What to do with the [lockfile](../../10-mops.lock.md).
 
 Possible values:
 - `update` — keep the lockfile in sync with current dependencies and verify file integrity (default outside CI). Pass explicitly to force regeneration if the lockfile is stale or corrupt.
@@ -46,4 +46,4 @@ Note: explicit `--lock check` also errors when the lock is missing; the deprecat
 
 `mops add`, `mops remove`, `mops update`, and `mops sync` are unaffected — they always default to updating the lockfile.
 
-See [CI environments](/mops.lock#ci-environments) on the mops.lock page for full details.
+See [CI environments](../../10-mops.lock.md#ci-environments) on the mops.lock page for full details.

--- a/docs/versioned_docs/version-2.x/cli/1-deps/03-mops-outdated.md
+++ b/docs/versioned_docs/version-2.x/cli/1-deps/03-mops-outdated.md
@@ -14,14 +14,14 @@ mops outdated
 
 ### `--major`
 
-Also report updates that cross the caret bound. Mirrors [`mops update --major`](/cli/mops-update#--major).
+Also report updates that cross the caret bound. Mirrors [`mops update --major`](./04-mops-update.md#--major).
 ```
 mops outdated --major
 ```
 
 ### `--patch`
 
-Restrict reported updates to patch versions only. Mirrors [`mops update --patch`](/cli/mops-update#--patch).
+Restrict reported updates to patch versions only. Mirrors [`mops update --patch`](./04-mops-update.md#--patch).
 ```
 mops outdated --patch
 ```

--- a/docs/versioned_docs/version-2.x/cli/1-deps/04-mops-update.md
+++ b/docs/versioned_docs/version-2.x/cli/1-deps/04-mops-update.md
@@ -44,7 +44,7 @@ Mutually exclusive with [`--major`](#--major).
 
 ### `--lock`
 
-What to do with the [lockfile](/mops.lock).
+What to do with the [lockfile](../../10-mops.lock.md).
 
 Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 

--- a/docs/versioned_docs/version-2.x/cli/1-deps/05-mops-sync.md
+++ b/docs/versioned_docs/version-2.x/cli/1-deps/05-mops-sync.md
@@ -17,7 +17,7 @@ mops sync
 
 ### `--lock`
 
-What to do with the [lockfile](/mops.lock).
+What to do with the [lockfile](../../10-mops.lock.md).
 
 Default: `update` (create or refresh the lockfile, then verify). Unaffected by the `CI` environment variable — dependency-mutating commands always update the lock by default.
 

--- a/docs/versioned_docs/version-2.x/cli/2-publish/01-mops-publish.md
+++ b/docs/versioned_docs/version-2.x/cli/2-publish/01-mops-publish.md
@@ -10,7 +10,7 @@ Publish package to the mops registry
 mops publish
 ```
 
-You need to [import identity](/cli/mops-user-import) before publishing a package.
+You need to [import identity](../3-user/01-mops-user-import.md) before publishing a package.
 
 Tests will be run before publishing to ensure the package works correctly.
 

--- a/docs/versioned_docs/version-2.x/cli/2-publish/05-mops-owner.md
+++ b/docs/versioned_docs/version-2.x/cli/2-publish/05-mops-owner.md
@@ -8,7 +8,7 @@ sidebar_label: mops owner
 List, add or remove owners of a package.
 
 :::info
-Check the [Package owners and maintainers](/package-owners-and-maintainers) for more information.
+Check the [Package owners and maintainers](../../articles/03-package-owners-and-maintainers.md) for more information.
 :::
 
 ## `mops owner`

--- a/docs/versioned_docs/version-2.x/cli/2-publish/06-mops-maintainer.md
+++ b/docs/versioned_docs/version-2.x/cli/2-publish/06-mops-maintainer.md
@@ -8,7 +8,7 @@ sidebar_label: mops maintainer
 List, add or remove  maintainers of a package.
 
 :::info
-Check the [Package owners and maintainers](/package-owners-and-maintainers) for more information.
+Check the [Package owners and maintainers](../../articles/03-package-owners-and-maintainers.md) for more information.
 :::
 
 ## `mops maintainer`

--- a/docs/versioned_docs/version-2.x/cli/4-dev/02-mops-bench.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/02-mops-bench.md
@@ -30,7 +30,7 @@ Under the hood, Mops will:
 
 The number you get is for the exact wasm the chosen replica runs, and the two replicas install it differently:
 
-- **With [`[optimize]`](/mops.toml#optimize)** — `mops bench` runs `wasm-opt` on the module before deploy (same pass as `mops build`). Prefer this when you want bench numbers to match an optimized deploy artifact. When that pass **succeeds**, the deprecated `dfx` replica path does **not** apply a second `optimize: "cycles"` pass (on soft-fail, dfx still may). Pass [`--no-optimize`](#--no-optimize) to skip the `wasm-opt` pass for a single run without editing `mops.toml`.
+- **With [`[optimize]`](../../09-mops.toml.md#optimize)** — `mops bench` runs `wasm-opt` on the module before deploy (same pass as `mops build`). Prefer this when you want bench numbers to match an optimized deploy artifact. When that pass **succeeds**, the deprecated `dfx` replica path does **not** apply a second `optimize: "cycles"` pass (on soft-fail, dfx still may). Pass [`--no-optimize`](#--no-optimize) to skip the `wasm-opt` pass for a single run without editing `mops.toml`.
 - **Without `[optimize]`**:
   - **`pocket-ic`** runs the raw `moc` output — **no optimization**.
   - **`dfx`** post-optimizes before install (`optimize: "cycles"`, via `ic-wasm`), so instruction counts can be lower — and that path fails on EOP Motoko (Table64), falling back to unoptimized Wasm.
@@ -89,7 +89,7 @@ Use it to measure a canister that still uses legacy persistence. Has no effect w
 
 ### `--no-optimize`
 
-Skip the [`[optimize]`](/mops.toml#optimize) `wasm-opt` pass for this run, even when it is configured in `mops.toml`. Has no effect when `[optimize]` is not set. The `dfx` replica may still apply its own `optimize: "cycles"` pass on deploy — only the `pocket-ic` replica then runs the raw `moc` output.
+Skip the [`[optimize]`](../../09-mops.toml.md#optimize) `wasm-opt` pass for this run, even when it is configured in `mops.toml`. Has no effect when `[optimize]` is not set. The `dfx` replica may still apply its own `optimize: "cycles"` pass on deploy — only the `pocket-ic` replica then runs the raw `moc` output.
 
 ```
 mops bench --no-optimize

--- a/docs/versioned_docs/version-2.x/cli/4-dev/03-mops-build.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/03-mops-build.md
@@ -23,7 +23,7 @@ For each canister, three files are written to the output directory (default `.mo
 
 If the canister config sets a `candid` field, the generated `.did` is also checked for compatibility against it.
 
-When [`[optimize]`](/mops.toml#optimize) is set in `mops.toml`, mops runs Binaryen `wasm-opt` on the Wasm **after** candid metadata is embedded. Defaults are `-O3 -g` (see the config reference). Failures warn and leave the unoptimized module. Pass [`--no-optimize`](#--no-optimize) to skip this pass for a single run.
+When [`[optimize]`](../../09-mops.toml.md#optimize) is set in `mops.toml`, mops runs Binaryen `wasm-opt` on the Wasm **after** candid metadata is embedded. Defaults are `-O3 -g` (see the config reference). Failures warn and leave the unoptimized module. Pass [`--no-optimize`](#--no-optimize) to skip this pass for a single run.
 
 ### Examples
 
@@ -70,7 +70,7 @@ mops build --output ./dist
 
 ### `--no-optimize`
 
-Skip the [`[optimize]`](/mops.toml#optimize) `wasm-opt` post-pass for this run, even when it is configured in `mops.toml`. Has no effect when `[optimize]` is not set. Useful for a faster build or to produce an unoptimized module for debugging without editing `mops.toml`.
+Skip the [`[optimize]`](../../09-mops.toml.md#optimize) `wasm-opt` post-pass for this run, even when it is configured in `mops.toml`. Has no effect when `[optimize]` is not set. Useful for a faster build or to produce an unoptimized module for debugging without editing `mops.toml`.
 
 ```
 mops build --no-optimize
@@ -111,7 +111,7 @@ The `--output` CLI flag takes precedence over this config value.
 
 When a canister has a `[canisters.<name>.migrations]` section in `mops.toml`, `mops build` automatically injects the `--enhanced-migration` flag. The full migration chain is compiled into the WASM.
 
-If `mops check` passes but `mops build` fails while [`check-limit`](/cli/mops-migrate#chain-trimming) is set, re-run `mops check --no-check-limit` to surface the issue — `check` trims the chain, while `build` compiles all of it.
+If `mops check` passes but `mops build` fails while [`check-limit`](./08-mops-migrate.md#chain-trimming) is set, re-run `mops check --no-check-limit` to surface the issue — `check` trims the chain, while `build` compiles all of it.
 
 ## Candid Compatibility
 
@@ -119,7 +119,7 @@ If a `candid` field is specified in the canister configuration, the build comman
 
 If the compatibility check fails, the build will fail with an error message.
 
-For manual compatibility checking, see [`mops check-candid`](/cli/mops-check-candid).
+For manual compatibility checking, see [`mops check-candid`](./06-mops-check-candid.md).
 
 ## Stable Types
 
@@ -134,4 +134,4 @@ path = ".deployed/backend.most"
 
 With this in place, `mops check` automatically verifies upgrade compatibility on every run.
 
-See [`mops check`](/cli/mops-check#stable-compatibility-checking) for full configuration details.
+See [`mops check`](./04-mops-check.md#stable-compatibility-checking) for full configuration details.

--- a/docs/versioned_docs/version-2.x/cli/4-dev/04-mops-check.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/04-mops-check.md
@@ -85,7 +85,7 @@ Print the full `moc` invocation before running it.
 
 ### `--no-check-limit`
 
-Use the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. Useful with `--fix` to autofix issues in older migrations that the limit would normally skip. Also suppresses the pending-migration warning that runs when `check-limit` is set. See [chain trimming](/cli/mops-migrate#chain-trimming).
+Use the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. Useful with `--fix` to autofix issues in older migrations that the limit would normally skip. Also suppresses the pending-migration warning that runs when `check-limit` is set. See [chain trimming](./08-mops-migrate.md#chain-trimming).
 
 ```
 mops check --fix --no-check-limit
@@ -100,7 +100,7 @@ mops check -- -Werror
 ```
 
 :::tip
-Global `moc` flags can be configured in `mops.toml` under `[moc].args` so they don't need to be passed on every invocation. See [`mops.toml` reference](/mops.toml#moc).
+Global `moc` flags can be configured in `mops.toml` under `[moc].args` so they don't need to be passed on every invocation. See [`mops.toml` reference](../../09-mops.toml.md#moc).
 :::
 
 ## Stable compatibility checking
@@ -122,9 +122,9 @@ If the file at `path` doesn't exist, the check fails with an error. For initial 
 actor { };
 ```
 
-For more details, see [`mops check-stable`](/cli/mops-check-stable).
+For more details, see [`mops check-stable`](./05-mops-check-stable.md).
 
-When `[canisters.<name>.migrations].check-limit` is set, the stable check compares the deployed `.most` baseline against the local chain after compatibility checking. If more migrations are pending than `check-limit` allows, mops reports a diagnostic naming the latest pending file to fold into. If compat already failed, this replaces the misleading `moc` error; if compat passed anyway, it is shown as a warning. Only applies when the baseline is a committed `.most` file configured via `[check-stable].path` (not a `.mo` source passed on the command line). See [chain trimming](/cli/mops-migrate#chain-trimming).
+When `[canisters.<name>.migrations].check-limit` is set, the stable check compares the deployed `.most` baseline against the local chain after compatibility checking. If more migrations are pending than `check-limit` allows, mops reports a diagnostic naming the latest pending file to fold into. If compat already failed, this replaces the misleading `moc` error; if compat passed anyway, it is shown as a warning. Only applies when the baseline is a committed `.most` file configured via `[check-stable].path` (not a `.mo` source passed on the command line). See [chain trimming](./08-mops-migrate.md#chain-trimming).
 
 ## Enhanced migration support
 
@@ -134,7 +134,7 @@ If a stable compatibility check fails and `[migrations]` is configured, a hint i
 
 ## Lint integration
 
-After type-checking succeeds, `mops check` automatically runs [`mops lint`](/cli/mops-lint) when `lintoko` is pinned in `[toolchain]`.
+After type-checking succeeds, `mops check` automatically runs [`mops lint`](./07-mops-lint.md) when `lintoko` is pinned in `[toolchain]`.
 
 This means `mops check` is the single command for all correctness checks — type errors and lint violations are both caught in one pass.
 
@@ -149,5 +149,5 @@ When file paths are passed explicitly (e.g. `mops check src/Main.mo`), linting i
 :::
 
 :::info
-`mops check` only type-checks files — it does not produce any compiled output. To compile canisters, use [`mops build`](/cli/mops-build).
+`mops check` only type-checks files — it does not produce any compiled output. To compile canisters, use [`mops build`](./03-mops-build.md).
 :::

--- a/docs/versioned_docs/version-2.x/cli/4-dev/05-mops-check-stable.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/05-mops-check-stable.md
@@ -76,7 +76,7 @@ mops check-stable <old-file> [canister]
 - **`[canister]`** — Name of the canister to check against. When omitted, auto-detected if exactly one canister is defined; errors if multiple canisters exist.
 
 :::tip
-`mops build` generates a `.most` file for each canister alongside `.wasm` and `.did`. Use [`mops deployed`](/cli/mops-deployed) as a post-deploy hook to promote that `.most` into a committed `deployed/<name>.most` baseline, and configure `[canisters.<name>.check-stable]` in `mops.toml` so `mops check-stable` (and `mops check`) verify upgrade safety automatically on every run.
+`mops build` generates a `.most` file for each canister alongside `.wasm` and `.did`. Use [`mops deployed`](./09-mops-deployed.md) as a post-deploy hook to promote that `.most` into a committed `deployed/<name>.most` baseline, and configure `[canisters.<name>.check-stable]` in `mops.toml` so `mops check-stable` (and `mops check`) verify upgrade safety automatically on every run.
 :::
 
 ## Options
@@ -87,7 +87,7 @@ Show detailed output including the `moc` commands being run and the intermediate
 
 ### `--no-check-limit`
 
-Use the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. See [chain trimming](/cli/mops-migrate#chain-trimming). Also suppresses the pending-migration warning that runs when `check-limit` is set.
+Use the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. See [chain trimming](./08-mops-migrate.md#chain-trimming). Also suppresses the pending-migration warning that runs when `check-limit` is set.
 
 ## Pending migration diagnostic
 
@@ -108,5 +108,5 @@ mops check-stable -- --experimental-stable-memory=1
 ```
 
 :::tip
-Global `moc` flags configured in `[moc].args` and per-canister flags in `[canisters.<name>].args` are automatically applied. See [`mops.toml` reference](/mops.toml#moc).
+Global `moc` flags configured in `[moc].args` and per-canister flags in `[canisters.<name>].args` are automatically applied. See [`mops.toml` reference](../../09-mops.toml.md#moc).
 :::

--- a/docs/versioned_docs/version-2.x/cli/4-dev/06-mops-check-candid.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/06-mops-check-candid.md
@@ -48,5 +48,5 @@ Breaking changes:
 - Make optional parameters required
 
 :::info
-The [`mops build`](/cli/mops-build) command automatically runs Candid compatibility checks when a `candid` field is specified in the canister configuration.
+The [`mops build`](./03-mops-build.md) command automatically runs Candid compatibility checks when a `candid` field is specified in the canister configuration.
 :::

--- a/docs/versioned_docs/version-2.x/cli/4-dev/07-mops-lint.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/07-mops-lint.md
@@ -64,7 +64,7 @@ mops lint --rules ./rules-a --rules ./rules-b
 
 ### `--no-check-limit`
 
-Lint the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. See [chain trimming](/cli/mops-migrate#chain-trimming).
+Lint the full migration chain, ignoring `[canisters.<name>.migrations].check-limit`. See [chain trimming](./08-mops-migrate.md#chain-trimming).
 
 ## Configuration
 
@@ -158,4 +158,4 @@ my-package/
 
 Exits with a non-zero code if any lint errors are found.
 
-See also: [toolchain management](/cli/toolchain) to pin a `lintoko` version.
+See also: [toolchain management](../5-toolchain/01-toolchain-overview.md) to pin a `lintoko` version.

--- a/docs/versioned_docs/version-2.x/cli/4-dev/08-mops-migrate.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/08-mops-migrate.md
@@ -6,7 +6,7 @@ sidebar_label: mops migrate
 # `mops migrate`
 
 :::warning Experimental
-`mops migrate` is **experimental** and not recommended for general use yet — its commands and configuration may change. The recommended workflow is to create migration files directly in your `chain` directory; see [`[canisters.<name>.migrations]`](/mops.toml#canistersnamemigrations).
+`mops migrate` is **experimental** and not recommended for general use yet — its commands and configuration may change. The recommended workflow is to create migration files directly in your `chain` directory; see [`[canisters.<name>.migrations]`](../../09-mops.toml.md#canistersnamemigrations).
 :::
 
 Manage enhanced migration chains.
@@ -67,7 +67,7 @@ build-limit = 100
 
 `moc` diagnostics may point to a staged path under `.migrations-<canister>/`, which mops removes when the command finishes.
 
-See [`mops.toml` reference](/mops.toml#canistersnamemigrations) for all fields.
+See [`mops.toml` reference](../../09-mops.toml.md#canistersnamemigrations) for all fields.
 
 ## Typical workflow
 

--- a/docs/versioned_docs/version-2.x/cli/4-dev/09-mops-deployed.md
+++ b/docs/versioned_docs/version-2.x/cli/4-dev/09-mops-deployed.md
@@ -5,7 +5,7 @@ sidebar_label: mops deployed
 
 # `mops deployed`
 
-Post-deploy hook: promote the just-built `.most` stable-types file into a committed `deployed/` directory so [`mops check-stable`](/cli/mops-check-stable) compares against the deployed version on the next build.
+Post-deploy hook: promote the just-built `.most` stable-types file into a committed `deployed/` directory so [`mops check-stable`](./05-mops-check-stable.md) compares against the deployed version on the next build.
 
 ```
 mops deployed [canisters...]      # promote .most → deployed/
@@ -14,7 +14,7 @@ mops deployed init [canisters...] # one-time bootstrap: empty-actor baseline + w
 
 Run `mops deployed` after a successful deploy. It does **not** read from chain or wasm metadata — it only copies the local `.most` left by `mops build` into the project's `deployed/` directory so the on-disk stable-check baseline always matches the wasm you just deployed.
 
-For canister selection rules, see [`mops build`](/cli/mops-build).
+For canister selection rules, see [`mops build`](./03-mops-build.md).
 
 ## Lifecycle
 

--- a/docs/versioned_docs/version-2.x/cli/5-toolchain/01-toolchain-overview.md
+++ b/docs/versioned_docs/version-2.x/cli/5-toolchain/01-toolchain-overview.md
@@ -14,13 +14,13 @@ When you run `mops install` command, Mops will install the specified version of 
 - `wasmtime` - Wasmtime runtime (used by `mops test --mode wasi`)
 - `pocket-ic` - PocketIC replica (used by `mops bench --replica pocket-ic`). Versions below `9.0.0` are deprecated and will no longer be supported in mops v3.
 - `lintoko` - Extensible linter for Motoko ([https://github.com/caffeinelabs/lintoko](https://github.com/caffeinelabs/lintoko))
-- `wasm-opt` - Binaryen Wasm optimizer (used when [`[optimize]`](/mops.toml#optimize) is set)
+- `wasm-opt` - Binaryen Wasm optimizer (used when [`[optimize]`](../../09-mops.toml.md#optimize) is set)
 
 ## Specifying tool versions
 
 ### Option 1: Use `mops toolchain use` command
 
-You can use [`mops toolchain use`](/cli/mops-toolchain-use) command to install specific tool version and update `mops.toml` file.
+You can use [`mops toolchain use`](./03-mops-toolchain-use.md) command to install specific tool version and update `mops.toml` file.
 ```
 mops toolchain use moc 0.10.3
 mops toolchain use wasmtime 16.0.0
@@ -65,9 +65,9 @@ lintoko = "../custom-lintoko/bin/lintoko"
 
 ## Toolchain management commands
 
-- [`mops toolchain init`](/cli/mops-toolchain-init)
-- [`mops toolchain use`](/cli/mops-toolchain-use)
-- [`mops toolchain update`](/cli/mops-toolchain-update)
-- [`mops toolchain info`](/cli/mops-toolchain-info)
-- [`mops toolchain bin`](/cli/mops-toolchain-bin)
-- [`mops toolchain reset`](/cli/mops-toolchain-reset)
+- [`mops toolchain init`](./02-mops-toolchain-init.md)
+- [`mops toolchain use`](./03-mops-toolchain-use.md)
+- [`mops toolchain update`](./04-mops-toolchain-update.md)
+- [`mops toolchain info`](./07-mops-toolchain-info.md)
+- [`mops toolchain bin`](./05-mops-toolchain-bin.md)
+- [`mops toolchain reset`](./06-mops-toolchain-rest.md)

--- a/docs/versioned_docs/version-2.x/cli/5-toolchain/02-mops-toolchain-init.md
+++ b/docs/versioned_docs/version-2.x/cli/5-toolchain/02-mops-toolchain-init.md
@@ -24,4 +24,4 @@ In CI environment, this command runs automatically when you run `mops install` o
 So no need to run it manually in GitHub Actions.
 :::
 
-To undo changes made by this command, run [`mops toolchain reset`](/cli/mops-toolchain-reset) command.
+To undo changes made by this command, run [`mops toolchain reset`](./06-mops-toolchain-rest.md) command.

--- a/docs/versioned_docs/version-2.x/cli/5-toolchain/06-mops-toolchain-rest.md
+++ b/docs/versioned_docs/version-2.x/cli/5-toolchain/06-mops-toolchain-rest.md
@@ -11,4 +11,4 @@ Uninstall toolchain management.
 mops toolchain reset
 ```
 
-This command will undo changes made by [`mops toolchain init`](/cli/mops-toolchain-init) command.
+This command will undo changes made by [`mops toolchain init`](./02-mops-toolchain-init.md) command.

--- a/docs/versioned_docs/version-2.x/cli/7-misc/03-mops-cache.md
+++ b/docs/versioned_docs/version-2.x/cli/7-misc/03-mops-cache.md
@@ -11,7 +11,7 @@ When you run `mops install`, `mops add <pkg>` or `mops toolchain use/update`, Mo
 
 Local cache directory is created in the project root in the `.mops` directory.
 
-The integrity of cached files is verified using the [mops.lock](/mops.lock) file.
+The integrity of cached files is verified using the [mops.lock](../../10-mops.lock.md) file.
 
 ### `mops cache show`
 

--- a/docs/versioned_docs/version-2.x/cli/7-misc/05-mops-moc-args.md
+++ b/docs/versioned_docs/version-2.x/cli/7-misc/05-mops-moc-args.md
@@ -29,4 +29,4 @@ $ mops moc-args
 
 Each flag is printed on its own line.
 
-See also: [`[moc]` config section](/mops.toml#moc).
+See also: [`[moc]` config section](../../09-mops.toml.md#moc).


### PR DESCRIPTION
A reader on `/2.x/mops.toml` who clicked an in-body link landed on the **v3** page at the site root — past the unmaintained banner, with nothing indicating the version had changed. Docusaurus version-resolves relative markdown links but leaves site-absolute paths untouched, so `[mops build](/cli/mops-build)` in the frozen tree emitted `href="/cli/mops-build"`.

Invisible right now, because #687's snapshot is byte-identical to the current tree. It would have started misdirecting readers the moment v3 content landed — and `v3` already diverges by 21 files.

Before, on `build/2.x/mops.toml/index.html`, ten content links pointed at the current line (`/cli/mops-build`, `/cli/mops-check`, `/mops.lock`, …). After:

```
in-version: 10  /2.x/cli/mops-build, /2.x/cli/mops-check, …
root-line :  1  /            (site-root breadcrumb)

remaining absolute hrefs on the page:
  href="/mops.toml"   ×2  — version dropdown "3.x (unreleased)", and the
                            unmaintained banner's "latest version" link
```

Both of those should point at the current line, so they are left alone. The current tree is unchanged: `build/mops.toml/index.html` still links to `/cli/mops-build`.

## What changed

76 links in each tree, 27 files each. Applied to `docs/docs/` as well as the snapshot, so the current line is correct and future `docusaurus docs:version` cuts inherit the fix rather than freezing the bug again.

Anchor fragments are preserved — 23 links carry one (`#optimize`, `#moc`, `#chain-trimming`, `#canistersnamemigrations`, `#ci-environments`).

Targets were resolved through each page's `slug:` frontmatter rather than guessed from filenames. `01-quick-start.md` has no slug, so its route is derived the way Docusaurus does it, by stripping the numeric prefix.

## Worth noting

Relative links are validated at build time. With `onBrokenLinks: "throw"`, a typo in a relative path now fails the build, where an absolute path would have shipped and 404'd — a small durability win beyond the version-correctness fix.

Closes #688.