### PR TITLE
ci: run CI on pushes to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - v3
   pull_request:
 
 permissions:

--- a/.github/workflows/cli-bundle.yml
+++ b/.github/workflows/cli-bundle.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - v3
   pull_request:
 
 permissions:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - v3
   pull_request:
 
 concurrency:

--- a/.github/workflows/mops-test.yml
+++ b/.github/workflows/mops-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - v3
   pull_request:
 
 permissions:


### PR DESCRIPTION
Pushing to `v3` ran no checks at all. `ci.yml`, `cli-bundle.yml` and `mops-test.yml` trigger on pushes to `main`/`master` and on `pull_request`, so a merge into the integration branch was validated only by whichever PR happened to be based on it next — and when something breaks that way, the failure surfaces on an unrelated PR and is awkward to attribute to the merge that caused it.

Adding `v3` to all three workflows behind the required checks rather than to `ci.yml` alone: `ci-ok`, `ci-ok-cli` and `ci-ok-mops` come from three separate files, so touching one would leave two of the three required checks unrun on a `v3` push. `code-quality.yml` is included for parity — it already runs on `main` pushes and is cheap.

This matters more now that admin bypass is disabled on both branches: everything reaches `v3` through a PR, and the post-merge state of the branch should be verified in its own right rather than inferred.

No behavior change for PRs — those already ran on `pull_request` regardless of target branch.